### PR TITLE
xRDRemoteApp: Allow for multiple values with UserGroups parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated filename for CHANGELOG.MD to CHANGELOG.md
+- Changes to xRemoteApp
+  - Updating `UserGroups` parameter to allow for an array to be supplied
+  - Updating comparison of current properties and supplied parameters by moving
+    to the DscResource.Common `Test-DscParameterState` cmdlet. This was necessary
+    to allow for the change with the `UserGroups` parameter to allow an array object.
+- Change to xRDGatewayConfiguration
+  - Updated call to `Set-RDDeploymentGatewayConfiguration` cmdlet to use `ErrorAction` 'Stop'
+  - Updated call to `Set-RDDeploymentGatewayConfiguration` cmdlet to use a splat for better formatting
+- Changes to tests
+  - xRDRemoteApp
+    - Fixed tests for error scenarios to behave correctly
+  - xRDGatewayConfiguration
+    - Fixed tests for error scenarios to behave correctly
 
 ## 2.0.0
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Please check out common DSC Community [contributing guidelines](https://dsccommu
 * **RequiredCommandLine**: Specifies a string that contains command-line arguments that the client can use at connection time with the RemoteApp program.
 * **IconIndex**: Specifies the index within the icon file (specified by the IconPath parameter) where the RemoteApp program's icon can be found.
 * **IconPath**: Specifies the path to a file containing the icon to display for the RemoteApp program identified by the Alias parameter.
-* **UserGroups**: Specifies a domain group that can view the RemoteApp in RD Web Access, and in RemoteApp and Desktop Connections.  To allow all users to see a RemoteApp program, provide a value of Null.
+* **UserGroups**: Specifies a list of domain groups that can view the RemoteApp in RD Web Access, and in RemoteApp and Desktop Connections.  To allow all users to see a RemoteApp program, provide a value of Null.
 * **ShowInWebAccess**: Specifies whether to show the RemoteApp program in the RD Web Access server, and in RemoteApp and Desktop Connections that the user subscribes to.
 
 ### xRDServer

--- a/source/DSCResources/MSFT_xRDGatewayConfiguration/MSFT_xRDGatewayConfiguration.psm1
+++ b/source/DSCResources/MSFT_xRDGatewayConfiguration/MSFT_xRDGatewayConfiguration.psm1
@@ -256,8 +256,17 @@ function Set-TargetResource
         write-verbose ">> UseCachedCredentials:  $UseCachedCredentials"
         write-verbose ">> BypassLocal:           $BypassLocal"
 
-        Set-RdDeploymentGatewayConfiguration -ConnectionBroker $ConnectionBroker -gatewaymode $GatewayMode -gatewayexternalfqdn $ExternalFqdn `
-            -logonmethod $LogonMethod -usecachedcredentials $UseCachedCredentials -bypasslocal $BypassLocal -force
+        $setRdDeploymentGatewayConfigurationParams = @{
+            ConnectionBroker = $ConnectionBroker
+            GatewayMode = $GatewayMode
+            GatewayExternalFqdn = $ExternalFqdn
+            LogonMethod = $LogonMethod
+            UseCachedCredentials = $UseCachedCredentials
+            BypassLocal = $BypassLocal
+            Force = $true
+            ErrorAction = 'Stop'
+        }
+        Set-RDDeploymentGatewayConfiguration @setRdDeploymentGatewayConfigurationParams
     }
     else   # 'DoNotUse' or 'Automatic'
     {

--- a/source/DSCResources/MSFT_xRDRemoteApp/MSFT_xRDRemoteApp.psm1
+++ b/source/DSCResources/MSFT_xRDRemoteApp/MSFT_xRDRemoteApp.psm1
@@ -222,7 +222,6 @@ function Test-TargetResource
         DesiredValues       = $PSBoundParameters
         TurnOffTypeChecking = $true
         SortArrayValues     = $true
-        Verbose             = $verbose
     }
 
     Test-DscParameterState @testDscParameterStateSplat

--- a/source/DSCResources/MSFT_xRDRemoteApp/MSFT_xRDRemoteApp.schema.mof
+++ b/source/DSCResources/MSFT_xRDRemoteApp/MSFT_xRDRemoteApp.schema.mof
@@ -13,6 +13,6 @@ class MSFT_xRDRemoteApp : OMI_BaseResource
     [write, Description("Specifies a string that contains command-line arguments that the client can use at connection time with the RemoteApp program. ")] string RequiredCommandLine;
     [write, Description("Specifies the index within the icon file (specified by the IconPath parameter) where the RemoteApp program's icon can be found.")] uint32 IconIndex;
     [write, Description("Specifies the path to a file containing the icon to display for the RemoteApp program identified by the Alias parameter.")] string IconPath;
-    [write, Description("Specifies a domain group that can view the RemoteApp in RD Web Access, and in RemoteApp and Desktop Connections. To allow all users to see a RemoteApp program, provide a value of Null.")] string UserGroups;
+    [write, Description("Specifies a list of domain groups that can view the RemoteApp in RD Web Access, and in RemoteApp and Desktop Connections. To allow all users to see a RemoteApp program, provide a value of Null.")] string UserGroups[];
     [write, Description("Specifies whether to show the RemoteApp program in the RD Web Access server, and in RemoteApp and Desktop Connections that the user subscribes to. ")] boolean ShowInWebAccess;
 };

--- a/tests/Unit/MSFT_xRDGatewayConfiguration.tests.ps1
+++ b/tests/Unit/MSFT_xRDGatewayConfiguration.tests.ps1
@@ -156,8 +156,9 @@ try
         Describe "$($script:DSCResourceName)\Set-TargetResource" {
             Context "Parameter Values,Validations and Errors" {
 
-                It "Should error when if GatewayMode is Custom and a parameter is missing." {
-                    {Set-TargetResource -ConnectionBroker "connectionbroker.lan" -GatewayMode "Custom"} | should throw
+                It 'Should error when if GatewayMode is Custom and a parameter is missing.' {
+                    { Set-TargetResource -ConnectionBroker 'connectionbroker.lan' -GatewayMode 'Custom' -ErrorAction Stop } |
+                        Should -Throw
                 }
             }
 
@@ -369,8 +370,9 @@ try
         Describe "$($script:DSCResourceName)\Set-TargetResource" {
             Context "Parameter Values,Validations and Errors" {
 
-                It "Should error when if GatewayMode is Custom and a parameter is missing." {
-                    {Set-TargetResource -ConnectionBroker "connectionbroker.lan" -GatewayMode "Custom"} | should throw
+                It 'Should error when if GatewayMode is Custom and a parameter is missing.' {
+                    { Set-TargetResource -ConnectionBroker 'connectionbroker.lan' -GatewayMode 'Custom' -ErrorAction Stop } |
+                        Should -Throw
                 }
             }
 

--- a/tests/Unit/MSFT_xRDRemoteApp.tests.ps1
+++ b/tests/Unit/MSFT_xRDRemoteApp.tests.ps1
@@ -41,21 +41,26 @@ try
             Alias = 'alias'
         }
 
-        $xRDRemoteAppSplat = @{
-            CollectionName = 'TestCollection'
-            DisplayName = 'MyCalc (1.0.0)'
-            FilePath = 'c:\windows\system32\calc.exe'
-            Alias = 'Test-MyCalc-(1.0.0)'
-            Ensure = 'Present'
-            FileVirtualPath = 'c:\windows\system32\calc.exe'
-            FolderName = 'Test'
-            CommandLineSetting = 'DoNotAllow'
+        $sourceRemoteAppValues = @{
+            CollectionName      = 'TestCollection'
+            DisplayName         = 'MyCalc (1.0.0)'
+            FilePath            = 'c:\windows\system32\calc.exe'
+            Alias               = 'Test-MyCalc-(1.0.0)'
+            Ensure              = 'Present'
+            FileVirtualPath     = 'c:\windows\system32\calc.exe'
+            FolderName          = 'Test'
+            CommandLineSetting  = 'DoNotAllow'
             RequiredCommandLine = 'my-cmd'
-            IconIndex = 0
-            IconPath = 'c:\windows\system32\calc.exe'
-            UserGroups = 'DOMAIN\MyAppGroup_DLG'
-            ShowInWebAccess = $true
+            IconIndex           = 0
+            IconPath            = 'c:\windows\system32\calc.exe'
+            UserGroups          = 'DOMAIN\MyAppGroup_DLG'
+            ShowInWebAccess     = $true
         }
+
+        $xRDRemoteAppSplat = $sourceRemoteAppValues.Clone()
+
+        $getRDRemoteApp = $xRDRemoteAppSplat.Clone()
+        $null = $getRDRemoteApp.Remove('Ensure')
 
         Import-Module RemoteDesktop -Force
 
@@ -72,7 +77,7 @@ try
                     { Get-TargetResource @xRDRemoteAppSplat } | Should Throw
                 }
 
-                $xRDRemoteAppSplat.CommandLineSetting = 'DoNotAllow'
+                $xRDRemoteAppSplat.CommandLineSetting = $sourceRemoteAppValues.CommandLineSetting
             }
 
             Context "When Get-TargetResource is called" {
@@ -85,25 +90,19 @@ try
                 }
 
                 Mock -CommandName Get-RDRemoteApp -MockWith {
-                    @{
-                        CollectionName = 'TestCollection'
-                        DisplayName = 'MyCalc (1.0.0)'
-                        FilePath = 'c:\windows\system32\calc.exe'
-                        Alias = 'Test-MyCalc-(1.0.0)'
-                        FileVirtualPath = 'c:\windows\system32\calc.exe'
-                        FolderName = 'Test'
-                        CommandLineSetting = 'DoNotAllow'
-                        RequiredCommandLine = 'my-cmd'
-                        IconIndex = 0
-                        IconPath = 'c:\windows\system32\calc.exe'
-                        UserGroups = 'DOMAIN\MyAppGroup_DLG'
-                        ShowInWebAccess = $true
-                    }
+                    $getRDRemoteApp
                 }
 
                 It 'Should return Ensure Present, given the RemoteApp is created' {
                     (Get-TargetResource @xRDRemoteAppSplat).Ensure | Should Be 'Present'
                 }
+
+                $userGroups = @('DOMAIN\RemoteApp_UserGroup1', 'DOMAIN\RemoteApp_UserGroup2')
+                $xRDRemoteAppSplat.UserGroups = $userGroups
+                It 'Should not generate an error, given that an array of UserGroups was specified' {
+                    { Get-TargetResource @xRDRemoteAppSplat } | Should -Not -Throw
+                }
+                $xRDRemoteAppSplat.UserGroups = $sourceRemoteAppValues.UserGroups
 
                 [System.Array] $commonParameters = [System.Management.Automation.PSCmdlet]::OptionalCommonParameters
                 $commonParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
@@ -152,7 +151,7 @@ try
                     { Get-TargetResource @xRDRemoteAppSplat } | Should Throw
                 }
 
-                $xRDRemoteAppSplat.CommandLineSetting = 'DoNotAllow'
+                $xRDRemoteAppSplat.CommandLineSetting = $sourceRemoteAppValues.CommandLineSetting
             }
 
             Context 'When Set-TargetResource actions are performed' {
@@ -168,19 +167,26 @@ try
                     Assert-MockCalled -CommandName New-RDRemoteApp -Times 1 -Scope It
                 }
 
-                Mock -CommandName Get-RDRemoteApp -MockWith { $true }
+                Mock -CommandName Get-RDRemoteApp -MockWith { $getRDRemoteApp }
 
                 It 'Should call Set-RDRemoteApp, given that the RemoteApp does exist and Ensure is set to Present' {
                     Set-TargetResource @xRDRemoteAppSplat
                     Assert-MockCalled -CommandName Set-RDRemoteApp -Times 1 -Scope It
                 }
 
+                $userGroups = @('DOMAIN\RemoteApp_UserGroup1', 'DOMAIN\RemoteApp_UserGroup2')
+                $xRDRemoteAppSplat.UserGroups = $userGroups
+                It 'Should not generate an error, given that an array of UserGroups was specified' {
+                    { Set-TargetResource @xRDRemoteAppSplat } | Should -Not -Throw
+                }
+                $xRDRemoteAppSplat.UserGroups = $sourceRemoteAppValues.UserGroups
+
                 $xRDRemoteAppSplat.Ensure = 'Absent'
                 It 'Should call Remove-RDRemoteApp, given that the RemoteApp exists and Ensure is set to Absent' {
                     Set-TargetResource @xRDRemoteAppSplat
                     Assert-MockCalled -CommandName Remove-RDRemoteApp -Times 1 -Scope It
                 }
-                $xRDRemoteAppSplat.Ensure = 'Present'
+                $xRDRemoteAppSplat.Ensure = $sourceRemoteAppValues.Ensure
 
                 Mock -CommandName Get-RDSessionCollection -MockWith {
                     Write-Error 'Collection not found!'
@@ -207,7 +213,7 @@ try
                     { Get-TargetResource @xRDRemoteAppSplat } | Should Throw
                 }
 
-                $xRDRemoteAppSplat.CommandLineSetting = 'DoNotAllow'
+                $xRDRemoteAppSplat.CommandLineSetting = $sourceRemoteAppValues.CommandLineSetting
             }
 
             Context 'Test output validation' {
@@ -219,20 +225,7 @@ try
                 }
 
                 Mock -CommandName Get-RDRemoteApp -MockWith {
-                    @{
-                        CollectionName = 'TestCollection'
-                        DisplayName = 'MyCalc (1.0.0)'
-                        FilePath = 'c:\windows\system32\calc.exe'
-                        Alias = 'Test-MyCalc-(1.0.0)'
-                        FileVirtualPath = 'c:\windows\system32\calc.exe'
-                        FolderName = 'Test'
-                        CommandLineSetting = 'DoNotAllow'
-                        RequiredCommandLine = 'my-cmd'
-                        IconIndex = 0
-                        IconPath = 'c:\windows\system32\calc.exe'
-                        UserGroups = 'DOMAIN\MyAppGroup_DLG'
-                        ShowInWebAccess = $true
-                    }
+                    $getRDRemoteApp
                 }
 
                 It 'Should return true, given that the RemoteApp does exist and Ensure is set to Present' {
@@ -243,23 +236,32 @@ try
                 It 'Should return false, given that the RemoteApp exists and Ensure is set to Absent' {
                     Test-TargetResource @xRDRemoteAppSplat | Should Be $false
                 }
-                $xRDRemoteAppSplat.Ensure = 'Present'
+                $xRDRemoteAppSplat.Ensure = $sourceRemoteAppValues.Ensure
 
+                $userGroups = @('DOMAIN\RemoteApp_UserGroup1', 'DOMAIN\RemoteApp_UserGroup2')
+                $xRDRemoteAppSplat.UserGroups = $userGroups
+                It 'Should not generate an error, given that an array of UserGroups was specified' {
+                    { Test-TargetResource @xRDRemoteAppSplat } | Should -Not -Throw
+                }
+
+                It 'Should return false, due to a mismatch in UserGroups' {
+                    Test-TargetResource @xRDRemoteAppSplat | Should Be $false
+                }
+
+                $getRDRemoteApp.UserGroups = $userGroups
                 Mock -CommandName Get-RDRemoteApp -MockWith {
-                    @{
-                        CollectionName = 'TestCollection'
-                        DisplayName = 'MyCalc (1.0.0)'
-                        FilePath = 'c:\windows\system32\calc.exe'
-                        Alias = 'Test-MyCalc-(1.0.0)'
-                        FileVirtualPath = 'c:\windows\system32\calc.exe'
-                        FolderName = 'Test'
-                        CommandLineSetting = 'Allow'
-                        RequiredCommandLine = 'my-cmd'
-                        IconIndex = 0
-                        IconPath = 'c:\windows\system32\calc.exe'
-                        UserGroups = 'DOMAIN\MyAppGroup_DLG'
-                        ShowInWebAccess = $true
-                    }
+                    $getRDRemoteApp
+                }
+
+                It 'Should return true, given that the comparison of UserGroups arrays succeeds' {
+                    Test-TargetResource @xRDRemoteAppSplat | Should Be $true
+                }
+                $xRDRemoteAppSplat.UserGroups = $sourceRemoteAppValues.UserGroups
+                $getRDRemoteApp.UserGroups = $sourceRemoteAppValues.UserGroups
+
+                $getRDRemoteApp.CommandLineSetting = 'Allow'
+                Mock -CommandName Get-RDRemoteApp -MockWith {
+                    $getRDRemoteApp
                 }
 
                 It 'Should return false, given that the RemoteApp exists and Ensure is set to Present and a single setting is misconfigured' {

--- a/tests/Unit/MSFT_xRDRemoteApp.tests.ps1
+++ b/tests/Unit/MSFT_xRDRemoteApp.tests.ps1
@@ -132,14 +132,8 @@ try
                 }
 
                 It 'Should generate an error, given that the CollectionName is not found in the SessionDeployment' {
-                    try
-                    {
-                        Get-TargetResource @xRDRemoteAppSplat -ErrorVariable collectionError
-                    }
-                    catch
-                    {
-                        $collectionError[-1].Exception.Message | Should Be 'Failed to lookup RD Session Collection TestCollection. Error: Collection not found!'
-                    }
+                    { Get-TargetResource @xRDRemoteAppSplat -ErrorAction Stop } |
+                        Should -Throw 'Failed to lookup RD Session Collection TestCollection. Error: Collection not found!'
                 }
             }
         }
@@ -193,14 +187,8 @@ try
                 }
 
                 It 'Should generate an error, given that the CollectionName is not found in the SessionDeployment' {
-                    try
-                    {
-                        Set-TargetResource @xRDRemoteAppSplat -ErrorVariable collectionError
-                    }
-                    catch
-                    {
-                        $collectionError[-1].Exception.Message | Should Be 'Failed to lookup RD Session Collection TestCollection. Error: Collection not found!'
-                    }
+                    { Set-TargetResource @xRDRemoteAppSplat -ErrorAction Stop } |
+                        Should -Throw 'Failed to lookup RD Session Collection TestCollection. Error: Collection not found!'
                 }
             }
         }
@@ -283,14 +271,8 @@ try
                 }
 
                 It 'Should generate an error, given that the CollectionName is not found in the SessionDeployment' {
-                    try
-                    {
-                        Test-TargetResource @xRDRemoteAppSplat -ErrorVariable collectionError
-                    }
-                    catch
-                    {
-                        $collectionError[-1].Exception.Message | Should Be 'Failed to lookup RD Session Collection TestCollection. Error: Collection not found!'
-                    }
+                    { Test-TargetResource @xRDRemoteAppSplat -ErrorAction Stop } |
+                        Should -Throw 'Failed to lookup RD Session Collection TestCollection. Error: Collection not found!'
                 }
             }
         }

--- a/tests/Unit/MSFT_xRDRemoteApp.tests.ps1
+++ b/tests/Unit/MSFT_xRDRemoteApp.tests.ps1
@@ -132,7 +132,7 @@ try
 
                 It 'Should generate an error, given that the CollectionName is not found in the SessionDeployment' {
                     { Get-TargetResource @xRDRemoteAppSplat -ErrorAction Stop } |
-                        Should -Throw 'Failed to lookup RD Session Collection TestCollection. Error: Collection not found!'
+                        Should -Throw -ExpectedMessage 'Failed to lookup RD Session Collection TestCollection. Error: Collection not found!'
                 }
             }
         }
@@ -194,7 +194,7 @@ try
 
                 It 'Should generate an error, given that the CollectionName is not found in the SessionDeployment' {
                     { Set-TargetResource @xRDRemoteAppSplat -ErrorAction Stop } |
-                        Should -Throw 'Failed to lookup RD Session Collection TestCollection. Error: Collection not found!'
+                        Should -Throw -ExpectedMessage 'Failed to lookup RD Session Collection TestCollection. Error: Collection not found!'
                 }
             }
         }
@@ -274,7 +274,7 @@ try
 
                 It 'Should generate an error, given that the CollectionName is not found in the SessionDeployment' {
                     { Test-TargetResource @xRDRemoteAppSplat -ErrorAction Stop } |
-                        Should -Throw 'Failed to lookup RD Session Collection TestCollection. Error: Collection not found!'
+                        Should -Throw -ExpectedMessage 'Failed to lookup RD Session Collection TestCollection. Error: Collection not found!'
                 }
             }
         }


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
<!--
    Replace this comment block with a description of your PR.
-->
This PR implements a mechanism to allow for multiple values to be supplied to the `UserGroups` parameter

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->
- Fixes #87 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section of file CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xremotedesktopsessionhost/88)
<!-- Reviewable:end -->
