### PR TITLE
xRDCertificateConfiguration: Prevents 'Get-RDServer'' not recognized error

### DIFF
--- a/source/DSCResources/MSFT_xRDCertificateConfiguration/MSFT_xRDCertificateConfiguration.psm1
+++ b/source/DSCResources/MSFT_xRDCertificateConfiguration/MSFT_xRDCertificateConfiguration.psm1
@@ -3,7 +3,7 @@ if (!(Test-xRemoteDesktopSessionHostOsRequirement))
 {
     throw "The minimum OS requirement was not met."
 }
-Import-Module RemoteDesktop
+Import-Module RemoteDesktop -Global
 $script:localizedData = Get-LocalizedData -ResourceName 'MSFT_xRDCertificateConfiguration'
 
 #######################################################################


### PR DESCRIPTION
#### Pull Request (PR) description

Fixes an issue that occurs in some circumstances:
'The term 'Get-RDServer' is not recognized as the name of a cmdlet'

#### This Pull Request (PR) fixes the following issues
    - Fixes #79


#### Task list
- [x] Added an entry under the Unreleased section of file CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
