### PR TITLE
xRDSessionCollection: Resolve Issue 106; always filter Get-RDSessionCollection result set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- xRDSessionCollection
+  - Always filter SessionCollection result; resolves [issue #106](https://github.com/dsccommunity/xRemoteDesktopSessionHost/issues/106)
+
 ## [2.1.0] - 2022-08-07
 
 ### Added

--- a/source/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
+++ b/source/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
@@ -35,7 +35,12 @@ function Get-TargetResource
     $Collection = Get-RDSessionCollection @params  | `
         Where-Object  CollectionName -eq $CollectionName
 
-    @{
+
+    if ($Collection.Count -eq 0) {
+        return $null
+    }
+
+    return @{
         "CollectionName" = $Collection.CollectionName
         "CollectionDescription" = $Collection.CollectionDescription
         "SessionHost" = $localhost

--- a/source/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
+++ b/source/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
@@ -40,7 +40,7 @@ function Get-TargetResource
         return $null
     }
 
-    if ($Collection.Count -gt 1) {
+    if ($Collection.GetType().Name -eq 'Array' -and $Collection.Count -gt 1) {
         Throw 'non-singular RDSessionCollection in result set'
     }
 

--- a/source/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
+++ b/source/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
@@ -26,11 +26,14 @@ function Get-TargetResource
         [string] $ConnectionBroker
     )
     Write-Verbose "Getting information about RDSH collection."
-    $Collection = Get-RDSessionCollection -CollectionName $CollectionName -ConnectionBroker $ConnectionBroker -ErrorAction SilentlyContinue
-    if ($Collection.count -gt 1)
-    {
-        $Collection = $Collection | Where-Object CollectionName -eq $CollectionName
+    $params = @{
+        CollectionName   = $CollectionName
+        ConnectionBroker = $ConnectionBroker
+        ErrorAction      = 'SilentlyContinue'
     }
+
+    $Collection = Get-RDSessionCollection @params  | `
+        Where-Object  CollectionName -eq $CollectionName
 
     @{
         "CollectionName" = $Collection.CollectionName

--- a/source/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
+++ b/source/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
@@ -36,11 +36,13 @@ function Get-TargetResource
         Where-Object  CollectionName -eq $CollectionName
 
 
-    if ($Collection.Count -eq 0) {
+    if ($Collection.Count -eq 0)
+    {
         return $null
     }
 
-    if ($Collection.GetType().Name -eq 'Array' -and $Collection.Count -gt 1) {
+    if ($Collection.GetType().Name -eq 'Array' -and $Collection.Count -gt 1)
+    {
         Throw 'non-singular RDSessionCollection in result set'
     }
 

--- a/source/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
+++ b/source/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
@@ -40,6 +40,10 @@ function Get-TargetResource
         return $null
     }
 
+    if ($Collection.Count -gt 1) {
+        Throw 'non-singular RDSessionCollection in result set'
+    }
+
     return @{
         "CollectionName" = $Collection.CollectionName
         "CollectionDescription" = $Collection.CollectionDescription

--- a/source/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
+++ b/source/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
@@ -41,9 +41,14 @@ function Get-TargetResource
         return $null
     }
 
-    if ($Collection.GetType().Name -eq 'Array' -and $Collection.Count -gt 1)
+    if ($Collection.Count -gt 1)
     {
-        throw 'non-singular RDSessionCollection in result set'
+        $CollectionType = $Collection.GetType()
+
+        if ($CollectionType.Name -eq 'Array' -or $CollectionType.BaseType.Name -eq 'Array')
+        {
+            throw 'non-singular RDSessionCollection in result set'
+        }
     }
 
     return @{

--- a/source/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
+++ b/source/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
@@ -43,7 +43,7 @@ function Get-TargetResource
 
     if ($Collection.GetType().Name -eq 'Array' -and $Collection.Count -gt 1)
     {
-        Throw 'non-singular RDSessionCollection in result set'
+        throw 'non-singular RDSessionCollection in result set'
     }
 
     return @{

--- a/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
+++ b/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
@@ -73,6 +73,18 @@ try
                     return $result
                 }
 
+                Mock -ParameterFilter { $CollectionName -and ($CollectionName -eq 'TestCollection4') } `
+                -CommandName Get-RDSessionCollection {
+                    return @(
+                        @{
+                            CollectionName = 'TestCollection3'
+                            CollectionDescription = 'Test Collection 3'
+                            SessionHost = $testSessionHost
+                            ConnectionBroker = $testConnectionBroker
+                        }
+                    )
+                }
+
             Context "Parameter Values,Validations and Errors" {
 
                 It "Should error when CollectionName length is greater than 256" {

--- a/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
+++ b/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
@@ -118,7 +118,7 @@ try
                 }
             }
 
-            Context "None-existent Session Collection requested" {
+            Context "Non-existent Session Collection requested" {
 
                 It "Should return empty result set when requested CollectionName does not match single existing Session Collection (Win 2019)" {
                     Get-TargetResource @nonExistentTargetResourceCall1 | Should BeNullOrEmpty

--- a/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
+++ b/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
@@ -135,7 +135,7 @@ try
                 Mock -CommandName Add-RDSessionHost
 
                 It 'Given the configuration is executed on the Connection Broker, New-RDSessionCollection is called' {
-                    Set-TargetResource -CollectionName $testcollectionName -ConnectionBroker ([System.Net.Dns]::GetHostByName((hostname)).HostName) -SessionHost $testSessionHost
+                    Set-TargetResource -CollectionName $testCollection[0].Name -ConnectionBroker ([System.Net.Dns]::GetHostByName((hostname)).HostName) -SessionHost $testSessionHost
                     Assert-MockCalled -CommandName New-RDSessionCollection -Times 1 -Scope It
                 }
 

--- a/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
+++ b/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
@@ -85,6 +85,11 @@ try
                     )
                 }
 
+                Mock -ParameterFilter { $CollectionName -and ($CollectionName -eq 'TestCollection5') } `
+                -CommandName Get-RDSessionCollection {
+                    return $null
+                }
+
             Context "Parameter Values,Validations and Errors" {
 
                 It "Should error when CollectionName length is greater than 256" {

--- a/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
+++ b/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
@@ -57,20 +57,21 @@ try
 
         #region Function Get-TargetResource
         Describe "$($script:DSCResourceName)\Get-TargetResource" {
-            Mock -CommandName Get-RDSessionCollection {
-                $result = @()
+            Mock -ParameterFilter { $CollectionName -and ($CollectionName -eq $testCollection[0].Name) } `
+                -CommandName Get-RDSessionCollection {
+                    $result = @()
 
-                foreach ($sessionCollection in $testCollection){
-                    $result += @{
-                        CollectionName = $sessionCollection.Name
-                        CollectionDescription = $sessionCollection.Description
-                        SessionHost = $testSessionHost
-                        ConnectionBroker = $testConnectionBroker
+                    foreach ($sessionCollection in $testCollection){
+                        $result += @{
+                            CollectionName = $sessionCollection.Name
+                            CollectionDescription = $sessionCollection.Description
+                            SessionHost = $testSessionHost
+                            ConnectionBroker = $testConnectionBroker
+                        }
                     }
-                }
 
-                return $result
-            }
+                    return $result
+                }
 
             Context "Parameter Values,Validations and Errors" {
 

--- a/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
+++ b/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
@@ -107,8 +107,13 @@ try
 
             Context "None-existent Session Collection requested" {
 
-                It "Should return empty result set when requested CollectionName does not match single existing Session Collection" {
+                It "Should return empty result set when requested CollectionName does not match single existing Session Collection (Win 2019)" {
                     $validTargetResourceCall.CollectionName = 'TestCollection4'
+                    Get-TargetResource @validTargetResourceCall | Should BeNullOrEmpty
+                }
+
+                It "Should return empty result set when requested CollectionName does not match single existing Session Collection (not Win 2019)" {
+                    $validTargetResourceCall.CollectionName = 'TestCollection5'
                     Get-TargetResource @validTargetResourceCall | Should BeNullOrEmpty
                 }
             }

--- a/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
+++ b/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
@@ -53,6 +53,18 @@ try
             ConnectionBroker = $testConnectionBroker
         }
 
+        $nonExistentTargetResourceCall1 = @{
+            CollectionName =  'TestCollection4'
+            SessionHost = $testSessionHost
+            ConnectionBroker = $testConnectionBroker
+        }
+
+        $nonExistentTargetResourceCall2 = @{
+            CollectionName =  'TestCollection5'
+            SessionHost = $testSessionHost
+            ConnectionBroker = $testConnectionBroker
+        }
+
         Import-Module RemoteDesktop -Force
 
         #region Function Get-TargetResource
@@ -109,13 +121,11 @@ try
             Context "None-existent Session Collection requested" {
 
                 It "Should return empty result set when requested CollectionName does not match single existing Session Collection (Win 2019)" {
-                    $validTargetResourceCall.CollectionName = 'TestCollection4'
-                    Get-TargetResource @validTargetResourceCall | Should BeNullOrEmpty
+                    Get-TargetResource @nonExistentTargetResourceCall1 | Should BeNullOrEmpty
                 }
 
                 It "Should return empty result set when requested CollectionName does not match single existing Session Collection (not Win 2019)" {
-                    $validTargetResourceCall.CollectionName = 'TestCollection5'
-                    Get-TargetResource @validTargetResourceCall | Should BeNullOrEmpty
+                    Get-TargetResource @nonExistentTargetResourceCall2 | Should BeNullOrEmpty
                 }
             }
         }

--- a/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
+++ b/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
@@ -82,7 +82,7 @@ try
                 It 'Calls Get-RDSessionCollection with CollectionName and ConnectionBroker parameters' {
                     Get-TargetResource @validTargetResourceCall
                     Assert-MockCalled -CommandName Get-RDSessionCollection -Times 1 -Scope It -ParameterFilter {
-                        $CollectionName -eq $testCollectionName -and
+                        $CollectionName -eq $testCollection[0].Name -and
                         $ConnectionBroker -eq $testConnectionBroker
                     }
                 }

--- a/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
+++ b/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
@@ -125,6 +125,29 @@ try
                     Get-TargetResource @nonExistentTargetResourceCall2 | Should BeNullOrEmpty
                 }
             }
+
+            Context "Two Session Collections exist with same CollectionName" {
+                Mock -CommandName Get-RDSessionCollection {
+                    $result = @()
+
+                    foreach ($sessionCollection in $testCollection)
+                    {
+                        $result += @{
+                            CollectionName = $testCollection[0].Name
+                            CollectionDescription = $sessionCollection.Description
+                            SessionHost = $testSessionHost
+                            ConnectionBroker = $testConnectionBroker
+                        }
+                    }
+
+                    return $result
+                }
+
+                It "should throw exception" {
+                    { Get-TargetResource @validTargetResourceCall } | Should throw
+                }
+            }
+
         }
         #endregion
 

--- a/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
+++ b/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
@@ -32,13 +32,23 @@ try
         $script:DSCResourceName    = 'MSFT_xRDSessionCollection'
 
         $testInvalidCollectionName = 'InvalidCollectionNameLongerThan256-12345678910111213141516171819202122232425262728142124124124awffjwifhw28qfhw27[q9aqfj2wai9fua29fua2fna29fja2fj29f2u192u4-[12fj2390fau2-9fu-9fu1-2ur1-2u149u2mfaweifjwifjw19wu-u2394u12-f2u1223fu-1f1239fy193413403mgjefas902311'
-        $testcollectionName = 'TestCollection'
+
+        $testCollection = @(
+            @{
+                Name        = 'TestCollection1'
+                Description = 'Test Collection 1'
+            }
+            @{
+                Name        = 'TestCollection2'
+                Description = 'Test Collection 2'
+            }
+        )
 
         $testSessionHost = 'localhost'
         $testConnectionBroker = 'localhost.fqdn'
 
         $validTargetResourceCall = @{
-            CollectionName = $testCollectionName
+            CollectionName =  $testCollection[0].Name
             SessionHost = $testSessionHost
             ConnectionBroker = $testConnectionBroker
         }
@@ -48,20 +58,18 @@ try
         #region Function Get-TargetResource
         Describe "$($script:DSCResourceName)\Get-TargetResource" {
             Mock -CommandName Get-RDSessionCollection {
-                return @(
-                    {
-                        CollectionName = $testCollectionName
-                        CollectionDescription = 'Test Collection'
-                        SessionHost = $testSessionHost
-                        ConnectionBroker = $testConnectionBroker
-                    },
-                    {
-                        CollectionName = $testCollectionName2
-                        CollectionDescription = 'Test Collection 2'
+                $result = @()
+
+                foreach ($sessionCollection in $testCollection){
+                    $result += @{
+                        CollectionName = $sessionCollection.Name
+                        CollectionDescription = $sessionCollection.Description
                         SessionHost = $testSessionHost
                         ConnectionBroker = $testConnectionBroker
                     }
-                )
+                }
+
+                return $result
             }
 
             Context "Parameter Values,Validations and Errors" {

--- a/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
+++ b/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
@@ -181,9 +181,9 @@ try
                 Mock -CommandName Get-RDSessionCollection -MockWith {
                     [pscustomobject]@{
                         AutoAssignPersonalDesktop = $false
-                        CollectionAlias = $testcollectionName
+                        CollectionAlias = $testCollection[0].Name
                         CollectionDescription = 'Pester Test Collection Output'
-                        CollectionName = $testcollectionName
+                        CollectionName = $testCollection[0].Name
                         CollectionType = 'PooledUnmanaged'
                         GrantAdministrativePrivilege = $false
                         ResourceType = 'Remote Desktop'

--- a/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
+++ b/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
@@ -61,7 +61,8 @@ try
                 -CommandName Get-RDSessionCollection {
                     $result = @()
 
-                    foreach ($sessionCollection in $testCollection){
+                    foreach ($sessionCollection in $testCollection)
+                    {
                         $result += @{
                             CollectionName = $sessionCollection.Name
                             CollectionDescription = $sessionCollection.Description

--- a/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
+++ b/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
@@ -104,6 +104,14 @@ try
                     }
                 }
             }
+
+            Context "None-existent Session Collection requested" {
+
+                It "Should return empty result set when requested CollectionName does not match single existing Session Collection" {
+                    $validTargetResourceCall.CollectionName = 'TestCollection4'
+                    Get-TargetResource @validTargetResourceCall | Should BeNullOrEmpty
+                }
+            }
         }
         #endregion
 


### PR DESCRIPTION
#### Pull Request (PR) description

_RDSessionCollection's_ `Get-TargetResource` has been amended so that it filters the RD Session Collections returned from `Get-RDSessionCollection` on CollectionName matching the desired $CollectionName, in _all_ circumstances.

PR also contains an attempt to improve the testing in this area.

#### This Pull Request (PR) fixes the following issues

- Fixes #106

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xremotedesktopsessionhost/107)
<!-- Reviewable:end -->
