### PR TITLE
xRDSessionCollection: Ignore errors from New-RDSessionCollection and instead check the collection is created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- xRDSessionCollection
+  - Ignore errors from New-RDSessionCollection and instead checks the collection is created; resolves [issue #105](https://github.com/dsccommunity/xRemoteDesktopSessionHost/issues/105)
+
 ## [2.1.0] - 2022-08-07
 
 ### Added

--- a/source/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
+++ b/source/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
@@ -59,6 +59,8 @@ function Set-TargetResource
         [Parameter()]
         [string] $ConnectionBroker
     )
+
+    $PSBoundParameters.Add('ErrorAction','SilentlyContinue')
     Write-Verbose "Creating a new RDSH collection."
     New-RDSessionCollection @PSBoundParameters
 }

--- a/source/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
+++ b/source/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
@@ -4,7 +4,6 @@ if (!(Test-xRemoteDesktopSessionHostOsRequirement))
     throw "The minimum OS requirement was not met."
 }
 Import-Module RemoteDesktop
-$localhost = [System.Net.Dns]::GetHostByName((hostname)).HostName
 
 #######################################################################
 # The Get-TargetResource cmdlet.
@@ -35,7 +34,7 @@ function Get-TargetResource
     @{
         "CollectionName" = $Collection.CollectionName
         "CollectionDescription" = $Collection.CollectionDescription
-        "SessionHost" = $localhost
+        "SessionHost" = $SessionHost
         "ConnectionBroker" = $ConnectionBroker
     }
 }
@@ -61,15 +60,7 @@ function Set-TargetResource
         [string] $ConnectionBroker
     )
     Write-Verbose "Creating a new RDSH collection."
-    if ($localhost -eq $ConnectionBroker)
-    {
-        New-RDSessionCollection @PSBoundParameters
-    }
-    else
-    {
-        $PSBoundParameters.Remove('CollectionDescription')
-        Add-RDSessionHost @PSBoundParameters
-    }
+    New-RDSessionCollection @PSBoundParameters
 }
 
 

--- a/source/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
+++ b/source/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1
@@ -63,6 +63,13 @@ function Set-TargetResource
     $PSBoundParameters.Add('ErrorAction','SilentlyContinue')
     Write-Verbose "Creating a new RDSH collection."
     New-RDSessionCollection @PSBoundParameters
+
+    $PSBoundParameters.Remove('ErrorAction')
+    if (-not (Test-TargetResource @PSBoundParameters))
+    {
+        Write-Verbose ('Session Collection ''{0}'' does not exist following attempted creation' -f $CollectionName)
+        throw ('''Get-RDSessionCollection -CollectionName {0} -ConnectionBroker {1}'' returns empty result set after call to ''New-RDSessionCollection''' -f $CollectionName,$ConnectionBroker)
+    }
 }
 
 

--- a/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
+++ b/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
@@ -90,14 +90,12 @@ try
                 }
             }
 
-            $ConnectionBroker = ([System.Net.Dns]::GetHostByName((hostname))).HostName
-
             Mock -CommandName Get-RDSessionCollection {
                 return @{
                     CollectionName        = $testCollectionName
                     CollectionDescription = 'Test Collection'
                     SessionHost           = $testSessionHost
-                    ConnectionBroker      = $ConnectionBroker
+                    ConnectionBroker      = $testConnectionBroker
                 }
             }
 
@@ -105,7 +103,7 @@ try
                 Mock -CommandName New-RDSessionCollection
 
                 It 'Given the configuration is applied, New-RDSessionCollection and Get-RDSessionCollection are called' {
-                    Set-TargetResource -CollectionName $testcollectionName -ConnectionBroker $ConnectionBroker -SessionHost $testSessionHost
+                    Set-TargetResource -CollectionName $testcollectionName -ConnectionBroker $testConnectionBroker -SessionHost $testSessionHost
                     Assert-MockCalled -CommandName New-RDSessionCollection -Times 1 -Scope Context
                     Assert-MockCalled -CommandName Get-RDSessionCollection -Times 1 -Scope Describe
                 }
@@ -120,7 +118,7 @@ try
                 }
 
                 It 'Given the configuration is applied, New-RDSessionCollection and Get-RDSessionCollection are called' {
-                    Set-TargetResource -CollectionName $testcollectionName -ConnectionBroker $ConnectionBroker -SessionHost $testSessionHost
+                    Set-TargetResource -CollectionName $testcollectionName -ConnectionBroker $testConnectionBroker -SessionHost $testSessionHost
                     Assert-MockCalled -CommandName New-RDSessionCollection -Times 1 -Scope Context
                     Assert-MockCalled -CommandName Get-RDSessionCollection -Times 1 -Scope Describe
                 }
@@ -132,11 +130,11 @@ try
                     return $null
                 }
 
-                $exceptionMessage = ( '''Get-RDSessionCollection -CollectionName {0} -ConnectionBroker {1}'' returns empty result set after call to ''New-RDSessionCollection''' -f $testCollectionName,$ConnectionBroker )
+                $exceptionMessage = ( '''Get-RDSessionCollection -CollectionName {0} -ConnectionBroker {1}'' returns empty result set after call to ''New-RDSessionCollection''' -f $testCollectionName,$testConnectionBroker )
 
                 It 'throws an exception' {
                     {
-                        Set-TargetResource -CollectionName $testcollectionName -ConnectionBroker $ConnectionBroker -SessionHost $testSessionHost
+                        Set-TargetResource -CollectionName $testcollectionName -ConnectionBroker $testConnectionBroker -SessionHost $testSessionHost
                     } | should throw $exceptionMessage
 
                     Assert-MockCalled -CommandName New-RDSessionCollection -Times 1 -Scope Context

--- a/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
+++ b/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
@@ -106,8 +106,8 @@ try
 
                 It 'Given the configuration is applied, New-RDSessionCollection and Get-RDSessionCollection are called' {
                     Set-TargetResource -CollectionName $testcollectionName -ConnectionBroker $ConnectionBroker -SessionHost $testSessionHost
-                    Assert-MockCalled -CommandName New-RDSessionCollection -Times 1 -Scope It
-                    Assert-MockCalled -CommandName Get-RDSessionCollection -Times 1 -Scope Context
+                    Assert-MockCalled -CommandName New-RDSessionCollection -Times 1 -Scope Context
+                    Assert-MockCalled -CommandName Get-RDSessionCollection -Times 1 -Scope Describe
                 }
             }
 
@@ -121,8 +121,8 @@ try
 
                 It 'Given the configuration is applied, New-RDSessionCollection and Get-RDSessionCollection are called' {
                     Set-TargetResource -CollectionName $testcollectionName -ConnectionBroker $ConnectionBroker -SessionHost $testSessionHost
-                    Assert-MockCalled -CommandName New-RDSessionCollection -Times 1 -Scope It
-                    Assert-MockCalled -CommandName Get-RDSessionCollection -Times 1 -Scope Context
+                    Assert-MockCalled -CommandName New-RDSessionCollection -Times 1 -Scope Context
+                    Assert-MockCalled -CommandName Get-RDSessionCollection -Times 1 -Scope Describe
                 }
             }
 

--- a/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
+++ b/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
@@ -92,12 +92,22 @@ try
 
             $ConnectionBroker = ([System.Net.Dns]::GetHostByName((hostname))).HostName
 
+            Mock -CommandName Get-RDSessionCollection {
+                return @{
+                    CollectionName        = $testCollectionName
+                    CollectionDescription = 'Test Collection'
+                    SessionHost           = $testSessionHost
+                    ConnectionBroker      = $ConnectionBroker
+                }
+            }
+
             Context 'Validate Set-TargetResource actions' {
                 Mock -CommandName New-RDSessionCollection
 
-                It 'Given the configuration is applied, New-RDSessionCollection is called' {
+                It 'Given the configuration is applied, New-RDSessionCollection and Get-RDSessionCollection are called' {
                     Set-TargetResource -CollectionName $testcollectionName -ConnectionBroker $ConnectionBroker -SessionHost $testSessionHost
                     Assert-MockCalled -CommandName New-RDSessionCollection -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Get-RDSessionCollection -Times 1 -Scope Context
                 }
             }
 
@@ -109,9 +119,10 @@ try
                     }
                 }
 
-                It 'Given the configuration is applied, New-RDSessionCollection is called' {
+                It 'Given the configuration is applied, New-RDSessionCollection and Get-RDSessionCollection are called' {
                     Set-TargetResource -CollectionName $testcollectionName -ConnectionBroker $ConnectionBroker -SessionHost $testSessionHost
                     Assert-MockCalled -CommandName New-RDSessionCollection -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Get-RDSessionCollection -Times 1 -Scope Context
                 }
             }
 

--- a/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
+++ b/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
@@ -101,7 +101,10 @@ try
 
             Context 'Errors thrown by New-RDSessionCollection are ignored' {
                 Mock -CommandName New-RDSessionCollection -MockWith {
-                    throw 'The property EncryptionLevel is configured by using Group Policy settings. Use the Group Policy Management Console to configure this property.'
+                    if ($ErrorActionPreference -ne 'SilentlyContinue')
+                    {
+                        throw 'The property EncryptionLevel is configured by using Group Policy settings. Use the Group Policy Management Console to configure this property.'
+                    }
                 }
 
                 It 'Given the configuration is applied, New-RDSessionCollection is called' {

--- a/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
+++ b/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
@@ -92,21 +92,10 @@ try
 
             Context 'Validate Set-TargetResource actions' {
                 Mock -CommandName New-RDSessionCollection
-                Mock -CommandName Add-RDSessionHost
 
-                It 'Given the configuration is executed on the Connection Broker, New-RDSessionCollection is called' {
+                It 'Given the configuration is applied, New-RDSessionCollection is called' {
                     Set-TargetResource -CollectionName $testcollectionName -ConnectionBroker ([System.Net.Dns]::GetHostByName((hostname)).HostName) -SessionHost $testSessionHost
                     Assert-MockCalled -CommandName New-RDSessionCollection -Times 1 -Scope It
-                }
-
-                It 'Given the configuration is not executed on the Connection Broker, Add-RDSessionHost is called' {
-                    Set-TargetResource @validTargetResourceCall
-                    Assert-MockCalled -CommandName Add-RDSessionHost -Times 1 -Scope It
-                }
-
-                It 'Given the configuration is not executed on the Connection Broker, and a description is passed, Add-RDSessionHost is called without the collection description' {
-                    Set-TargetResource @validTargetResourceCall -CollectionDescription 'Pester Test Collection Output'
-                    Assert-MockCalled -CommandName Add-RDSessionHost -Times 1 -Scope It
                 }
             }
         }

--- a/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
+++ b/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
@@ -98,6 +98,18 @@ try
                     Assert-MockCalled -CommandName New-RDSessionCollection -Times 1 -Scope It
                 }
             }
+
+            Context 'Errors thrown by New-RDSessionCollection are ignored' {
+                Mock -CommandName New-RDSessionCollection -MockWith {
+                    throw 'The property EncryptionLevel is configured by using Group Policy settings. Use the Group Policy Management Console to configure this property.'
+                }
+
+                It 'Given the configuration is applied, New-RDSessionCollection is called' {
+                    Set-TargetResource -CollectionName $testcollectionName -ConnectionBroker ([System.Net.Dns]::GetHostByName((hostname)).HostName) -SessionHost $testSessionHost
+                    Assert-MockCalled -CommandName New-RDSessionCollection -Times 1 -Scope It
+                }
+            }
+
         }
         #endregion
 

--- a/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
+++ b/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
@@ -126,6 +126,24 @@ try
                 }
             }
 
+            Context 'Get-RDSessionCollection returning empty result set after calling New-RDSessionCollection' {
+                Mock -CommandName New-RDSessionCollection
+                Mock -CommandName Get-RDSessionCollection {
+                    return $null
+                }
+
+                $exceptionMessage = ( '''Get-RDSessionCollection -CollectionName {0} -ConnectionBroker {1}'' returns empty result set after call to ''New-RDSessionCollection''' -f $testCollectionName,$ConnectionBroker )
+
+                It 'throws an exception' {
+                    {
+                        Set-TargetResource -CollectionName $testcollectionName -ConnectionBroker $ConnectionBroker -SessionHost $testSessionHost
+                    } | should throw $exceptionMessage
+
+                    Assert-MockCalled -CommandName New-RDSessionCollection -Times 1 -Scope Context
+                    Assert-MockCalled -CommandName Get-RDSessionCollection -Times 1 -Scope Describe
+                }
+            }
+
         }
         #endregion
 

--- a/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
+++ b/tests/Unit/MSFT_xRDSessionCollection.tests.ps1
@@ -90,11 +90,13 @@ try
                 }
             }
 
+            $ConnectionBroker = ([System.Net.Dns]::GetHostByName((hostname))).HostName
+
             Context 'Validate Set-TargetResource actions' {
                 Mock -CommandName New-RDSessionCollection
 
                 It 'Given the configuration is applied, New-RDSessionCollection is called' {
-                    Set-TargetResource -CollectionName $testcollectionName -ConnectionBroker ([System.Net.Dns]::GetHostByName((hostname)).HostName) -SessionHost $testSessionHost
+                    Set-TargetResource -CollectionName $testcollectionName -ConnectionBroker $ConnectionBroker -SessionHost $testSessionHost
                     Assert-MockCalled -CommandName New-RDSessionCollection -Times 1 -Scope It
                 }
             }
@@ -108,7 +110,7 @@ try
                 }
 
                 It 'Given the configuration is applied, New-RDSessionCollection is called' {
-                    Set-TargetResource -CollectionName $testcollectionName -ConnectionBroker ([System.Net.Dns]::GetHostByName((hostname)).HostName) -SessionHost $testSessionHost
+                    Set-TargetResource -CollectionName $testcollectionName -ConnectionBroker $ConnectionBroker -SessionHost $testSessionHost
                     Assert-MockCalled -CommandName New-RDSessionCollection -Times 1 -Scope It
                 }
             }


### PR DESCRIPTION
#### Pull Request (PR) description

This stops `xRDSessionCollection` when errors are returned from the underlying `New-RDSessionCollection` cmdlet because certain RD Host GPO settings are applied.

#### This Pull Request (PR) fixes the following issues

- Fixes #105

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xremotedesktopsessionhost/108)
<!-- Reviewable:end -->
