### PR TITLE
Update UserGroup parameter to accept an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - xRDSessionCollection
-  - Ignore errors from New-RDSessionCollection and instead checks the collection is created; resolves [issue #105](https://github.com/dsccommunity/xRemoteDesktopSessionHost/issues/105)
-  - Always filter SessionCollection result; resolves [issue #106](https://github.com/dsccommunity/xRemoteDesktopSessionHost/issues/106)
+  - Ignore errors from New-RDSessionCollection and instead checks the collection is created; resolves [issue #105](https://github.com/dsccommunity/xRemoteDesktopSessionHost/issues/105).
+- xRDSessionCollectionConfiguration
+  - Updating `UserGroups` parameter to allow for an array to be supplied,
+    resolves [issue #115](https://github.com/dsccommunity/xRemoteDesktopSessionHost/issues/115).
+- Always filter SessionCollection result; resolves [issue #106](https://github.com/dsccommunity/xRemoteDesktopSessionHost/issues/106).
 
 ### Added
 

--- a/source/DSCResources/MSFT_xRDSessionCollectionConfiguration/MSFT_xRDSessionCollectionConfiguration.psm1
+++ b/source/DSCResources/MSFT_xRDSessionCollectionConfiguration/MSFT_xRDSessionCollectionConfiguration.psm1
@@ -60,7 +60,7 @@ function Get-TargetResource
         [Parameter()]
         [boolean] $TemporaryFoldersDeletedOnExit,
         [Parameter()]
-        [string] $UserGroup,
+        [string[]] $UserGroup,
         [Parameter()]
         [string] $DiskPath,
         [Parameter()]
@@ -170,7 +170,7 @@ function Set-TargetResource
         [Parameter()]
         [boolean] $TemporaryFoldersDeletedOnExit,
         [Parameter()]
-        [string] $UserGroup,
+        [string[]] $UserGroup,
         [Parameter()]
         [string] $DiskPath,
         [Parameter()]
@@ -333,7 +333,7 @@ function Test-TargetResource
         [Parameter()]
         [boolean] $TemporaryFoldersDeletedOnExit,
         [Parameter()]
-        [string] $UserGroup,
+        [string[]] $UserGroup,
         [Parameter()]
         [string] $DiskPath,
         [Parameter()]

--- a/source/DSCResources/MSFT_xRDSessionCollectionConfiguration/MSFT_xRDSessionCollectionConfiguration.schema.mof
+++ b/source/DSCResources/MSFT_xRDSessionCollectionConfiguration/MSFT_xRDSessionCollectionConfiguration.schema.mof
@@ -19,7 +19,7 @@ class MSFT_xRDSessionCollectionConfiguration : OMI_BaseResource
     [write, Description("Specifies whether to enable the Remote Desktop Easy Print driver.")] boolean RDEasyPrintDriverEnabled;
     [write, Description("Specifies which security protocol to use. The acceptable values for this parameter are:  RDP, Negotiate, SSL.  The default value is Negotiate.")] string SecurityLayer;
     [write, Description("Specifies whether to delete temporary folders from the RD Session Host server for a disconnected session. ")] boolean TemporaryFoldersDeletedOnExit;
-    [write, Description("Specifies a domain group authorized to connect to the RD Session Host servers in a session collection. ")] string UserGroup;
+    [write, Description("Specifies a domain group authorized to connect to the RD Session Host servers in a session collection. ")] string UserGroup[];
     [write, Description("Specifies the target to store the User Profile Disks ")] string DiskPath;
     [write, Description("Specifies if this collection uses UserProfileDisks ")] boolean EnableUserProfileDisk;
     [write, Description("Specifies a list of strings for files to exclude from the user profile disk ")] string ExcludeFilePath[];


### PR DESCRIPTION
#### Pull Request (PR) description

Updating `UserGroups` parameter to allow for an array to be supplied, resolves [issue #115](https://github.com/dsccommunity/xRemoteDesktopSessionHost/issues/115).

#### This Pull Request (PR) fixes the following issues

- Fixes #115 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xRemoteDesktopSessionHost/123)
<!-- Reviewable:end -->
