### PR TITLE
All Resources: Fix CDXML module import scope for wmiprvse.exe (LCM)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,33 @@
-# Changelog for xRemoteDesktopSessionHost
+# Changelog for RemoteDesktopServices
 
 The format is based on and uses the types of changes according to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+
+- All DSC resources now import the RemoteDesktop CDXML module with
+  `Import-Module -Global` instead of `Assert-Module -ImportModule`. The
+  CDXML proxy commands were not visible inside `wmiprvse.exe` because
+  `Assert-Module` imported into its own function scope. This caused every
+  resource to fail with `The term 'Get-RDServer' is not recognized` when
+  applied by the LCM on Windows Server 2022/2025.
+- The RDMS service is now started before importing the RemoteDesktop module
+  in every resource function. Previously, only `DSC_RDSessionDeployment`
+  `Get-TargetResource` started the service, and only after the import
+  attempt, causing failures after reboot when the delayed-start service had
+  not yet registered its WMI namespace.
+
+### Changed
+
+- Added shared helper function `Import-RemoteDesktopModule` to the
+  `RemoteDesktopServicesDsc.Common` module to avoid duplicating the
+  RDMS-start-and-import logic across all 9 DSC resources.
+- Removed the now-redundant inline RDMS service start block from
+  `DSC_RDSessionDeployment` `Get-TargetResource`.
+
+## [4.0.0] - 2026-01-21
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,20 +12,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CDXML proxy commands were not visible inside `wmiprvse.exe` because
   `Assert-Module` imported into its own function scope. This caused every
   resource to fail with `The term 'Get-RDServer' is not recognized` when
-  applied by the LCM on Windows Server 2022/2025.
+  applied by the LCM on Windows Server 2022/2025
+  ([issue #136](https://github.com/dsccommunity/RemoteDesktopServicesDsc/issues/136)).
 - The RDMS service is now started before importing the RemoteDesktop module
   in every resource function. Previously, only `DSC_RDSessionDeployment`
   `Get-TargetResource` started the service, and only after the import
   attempt, causing failures after reboot when the delayed-start service had
-  not yet registered its WMI namespace.
+  not yet registered its WMI namespace
+  ([issue #136](https://github.com/dsccommunity/RemoteDesktopServicesDsc/issues/136)).
 
 ### Changed
 
 - Added shared helper function `Import-RemoteDesktopModule` to the
   `RemoteDesktopServicesDsc.Common` module to avoid duplicating the
-  RDMS-start-and-import logic across all 9 DSC resources.
+  RDMS-start-and-import logic across all 9 DSC resources
+  ([issue #136](https://github.com/dsccommunity/RemoteDesktopServicesDsc/issues/136)).
 - Removed the now-redundant inline RDMS service start block from
-  `DSC_RDSessionDeployment` `Get-TargetResource`.
+  `DSC_RDSessionDeployment` `Get-TargetResource`
+  ([issue #136](https://github.com/dsccommunity/RemoteDesktopServicesDsc/issues/136)).
 
 ## [4.0.0] - 2026-01-21
 

--- a/source/DSCResources/DSC_RDCertificateConfiguration/DSC_RDCertificateConfiguration.psm1
+++ b/source/DSCResources/DSC_RDCertificateConfiguration/DSC_RDCertificateConfiguration.psm1
@@ -43,7 +43,7 @@ function Get-TargetResource
         $script:localizedData.VerboseGetCertificate -f $Role, $ConnectionBroker
     )
 
-    Assert-Module -ModuleName 'RemoteDesktop' -ImportModule
+    Import-RemoteDesktopModule
 
     Get-RDCertificate -Role $Role -ConnectionBroker $ConnectionBroker
 }
@@ -77,7 +77,7 @@ function Set-TargetResource
         $Credential
     )
 
-    Assert-Module -ModuleName 'RemoteDesktop' -ImportModule
+    Import-RemoteDesktopModule
 
     $rdCertificateSplat = @{
         Role             = $Role

--- a/source/DSCResources/DSC_RDConnectionBrokerHAMode/DSC_RDConnectionBrokerHAMode.psm1
+++ b/source/DSCResources/DSC_RDConnectionBrokerHAMode/DSC_RDConnectionBrokerHAMode.psm1
@@ -44,7 +44,7 @@ function Get-TargetResource
         $ClientAccessName
     )
 
-    Assert-Module -ModuleName 'RemoteDesktop' -ImportModule
+    Import-RemoteDesktopModule
 
     Write-Verbose -Message ($script:localizedData.VerboseGetHAMode -f $ConnectionBroker, $ClientAccessName)
 
@@ -95,7 +95,7 @@ function Set-TargetResource
         $ClientAccessName
     )
 
-    Assert-Module -ModuleName 'RemoteDesktop' -ImportModule
+    Import-RemoteDesktopModule
 
     Write-Verbose -Message ($script:localizedData.VerboseConfigureHAMode -f $ConnectionBroker, $ClientAccessName)
 

--- a/source/DSCResources/DSC_RDGatewayConfiguration/DSC_RDGatewayConfiguration.psm1
+++ b/source/DSCResources/DSC_RDGatewayConfiguration/DSC_RDGatewayConfiguration.psm1
@@ -53,7 +53,7 @@ function Get-TargetResource
 
     Write-Verbose "Getting RD Gateway configuration from broker '$ConnectionBroker'..."
 
-    Assert-Module -ModuleName 'RemoteDesktop' -ImportModule
+    Import-RemoteDesktopModule
 
     $result = $null
 
@@ -133,7 +133,7 @@ function Set-TargetResource
 
     Write-Verbose "Starting RD Gateway configuration for the RD deployment at broker '$ConnectionBroker'..."
 
-    Assert-Module -ModuleName 'RemoteDesktop' -ImportModule
+    Import-RemoteDesktopModule
 
     $customModeParams = @(
         'ExternalFqdn',

--- a/source/DSCResources/DSC_RDLicenseConfiguration/DSC_RDLicenseConfiguration.psm1
+++ b/source/DSCResources/DSC_RDLicenseConfiguration/DSC_RDLicenseConfiguration.psm1
@@ -35,7 +35,7 @@ function Get-TargetResource
 
     Write-Verbose "Getting RD License server configuration from broker '$ConnectionBroker'..."
 
-    Assert-Module -ModuleName 'RemoteDesktop' -ImportModule
+    Import-RemoteDesktopModule
 
     $config = Get-RDLicenseConfiguration -ConnectionBroker $ConnectionBroker -ea SilentlyContinue
 
@@ -84,7 +84,7 @@ function Set-TargetResource
 
     Write-Verbose 'Starting RD License server configuration...'
 
-    Assert-Module -ModuleName 'RemoteDesktop' -ImportModule
+    Import-RemoteDesktopModule
 
     Write-Verbose ">> RD Connection Broker:  $($ConnectionBroker.ToLower())"
 

--- a/source/DSCResources/DSC_RDRemoteApp/DSC_RDRemoteApp.psm1
+++ b/source/DSCResources/DSC_RDRemoteApp/DSC_RDRemoteApp.psm1
@@ -74,7 +74,7 @@ function Get-TargetResource
         $ShowInWebAccess
     )
 
-    Assert-Module -ModuleName 'RemoteDesktop' -ImportModule
+    Import-RemoteDesktopModule
 
     try
     {
@@ -180,7 +180,7 @@ function Set-TargetResource
 
     )
 
-    Assert-Module -ModuleName 'RemoteDesktop' -ImportModule
+    Import-RemoteDesktopModule
 
     try
     {
@@ -275,7 +275,7 @@ function Test-TargetResource
 
     Write-Verbose 'Testing if RemoteApp is published.'
 
-    Assert-Module -ModuleName 'RemoteDesktop' -ImportModule
+    Import-RemoteDesktopModule
 
     try
     {

--- a/source/DSCResources/DSC_RDServer/DSC_RDServer.psm1
+++ b/source/DSCResources/DSC_RDServer/DSC_RDServer.psm1
@@ -40,7 +40,7 @@ function Get-TargetResource
         $GatewayExternalFqdn # only for RDS-Gateway
     )
 
-    Assert-Module -ModuleName 'RemoteDesktop' -ImportModule
+    Import-RemoteDesktopModule
 
     $result = @{
         ConnectionBroker    = $null
@@ -128,7 +128,7 @@ function Set-TargetResource
         $GatewayExternalFqdn # only for RDS-Gateway
     )
 
-    Assert-Module -ModuleName 'RemoteDesktop' -ImportModule
+    Import-RemoteDesktopModule
 
     if ($Role -eq 'RDS-Gateway')
     {

--- a/source/DSCResources/DSC_RDSessionCollection/DSC_RDSessionCollection.psm1
+++ b/source/DSCResources/DSC_RDSessionCollection/DSC_RDSessionCollection.psm1
@@ -42,7 +42,7 @@ function Get-TargetResource
 
     Write-Verbose -Message 'Getting information about RDSH collection.'
 
-    Assert-Module -ModuleName 'RemoteDesktop' -ImportModule
+    Import-RemoteDesktopModule
 
     $params = @{
         ConnectionBroker = $ConnectionBroker
@@ -109,7 +109,7 @@ function Set-TargetResource
         $Force
     )
 
-    Assert-Module -ModuleName 'RemoteDesktop' -ImportModule
+    Import-RemoteDesktopModule
 
     $currentStatus = Get-TargetResource @PSBoundParameters
 

--- a/source/DSCResources/DSC_RDSessionCollectionConfiguration/DSC_RDSessionCollectionConfiguration.psm1
+++ b/source/DSCResources/DSC_RDSessionCollectionConfiguration/DSC_RDSessionCollectionConfiguration.psm1
@@ -124,7 +124,7 @@ function Get-TargetResource
         $ExcludeFilePath
     )
 
-    Assert-Module -ModuleName 'RemoteDesktop' -ImportModule
+    Import-RemoteDesktopModule
 
     Write-Verbose "Getting currently configured RDSH Collection properties for collection $CollectionName"
 
@@ -294,7 +294,7 @@ function Set-TargetResource
 
     Write-Verbose 'Setting DSC collection properties'
 
-    Assert-Module -ModuleName 'RemoteDesktop' -ImportModule
+    Import-RemoteDesktopModule
 
     try
     {

--- a/source/DSCResources/DSC_RDSessionDeployment/DSC_RDSessionDeployment.psm1
+++ b/source/DSCResources/DSC_RDSessionDeployment/DSC_RDSessionDeployment.psm1
@@ -33,21 +33,7 @@ function Get-TargetResource
 
     Write-Verbose 'Getting list of RD Server roles.'
 
-    Assert-Module -ModuleName 'RemoteDesktop' -ImportModule
-
-    # Start service RDMS is needed because otherwise a reboot loop could happen due to
-    # the RDMS Service being on Delay-Start by default, and DSC kicks in too quickly after a reboot.
-    if ((Get-Service -Name RDMS -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Status) -ne 'Running')
-    {
-        try
-        {
-            Start-Service -Name RDMS -ErrorAction Stop
-        }
-        catch
-        {
-            Write-Warning "Failed to start RDMS service. Error: '$_'."
-        }
-    }
+    Import-RemoteDesktopModule
 
     $deployed = Get-RDServer -ConnectionBroker $ConnectionBroker -ErrorAction SilentlyContinue
 
@@ -80,7 +66,7 @@ function Set-TargetResource
         $WebAccessServer
     )
 
-    Assert-Module -ModuleName 'RemoteDesktop' -ImportModule
+    Import-RemoteDesktopModule
 
     $currentStatus = Get-TargetResource @PSBoundParameters
 

--- a/source/Modules/RemoteDesktopServicesDsc.Common/Public/Import-RemoteDesktopModule.ps1
+++ b/source/Modules/RemoteDesktopServicesDsc.Common/Public/Import-RemoteDesktopModule.ps1
@@ -1,0 +1,32 @@
+<#
+    .SYNOPSIS
+        Ensures the RDMS service is running and imports the RemoteDesktop CDXML module globally.
+
+    .DESCRIPTION
+        The RemoteDesktop module is a CDXML module whose proxy commands are generated at
+        import time. When DSC runs inside wmiprvse.exe, Import-Module defaults to function
+        scope, so the proxy commands are not visible to the calling DSC resource.
+
+        This function starts the RDMS service (required for the WMI namespace the CDXML
+        module connects to) and imports the module with -Global so the commands are
+        available in all scopes.
+#>
+
+function Import-RemoteDesktopModule
+{
+    [CmdletBinding()]
+    param ()
+
+    $rdmsService = Get-Service -Name RDMS -ErrorAction SilentlyContinue
+
+    if ($null -ne $rdmsService -and $rdmsService.Status -ne 'Running')
+    {
+        Start-Service -Name RDMS -ErrorAction Stop
+        Start-Sleep -Seconds 2
+    }
+
+    if (-not (Get-Module -Name RemoteDesktop))
+    {
+        Import-Module -Name RemoteDesktop -Global -Force -ErrorAction Stop
+    }
+}

--- a/source/Modules/RemoteDesktopServicesDsc.Common/Public/Import-RemoteDesktopModule.ps1
+++ b/source/Modules/RemoteDesktopServicesDsc.Common/Public/Import-RemoteDesktopModule.ps1
@@ -10,11 +10,24 @@
         This function starts the RDMS service (required for the WMI namespace the CDXML
         module connects to) and imports the module with -Global so the commands are
         available in all scopes.
+
+    .INPUTS
+        None
+
+    .OUTPUTS
+        None
+
+    .EXAMPLE
+        Import-RemoteDesktopModule
+
+        Starts the RDMS service if it is not running and imports the RemoteDesktop
+        module into the global scope so that its commands are available to DSC resources.
 #>
 
 function Import-RemoteDesktopModule
 {
     [CmdletBinding()]
+    [OutputType()]
     param ()
 
     $rdmsService = Get-Service -Name RDMS -ErrorAction SilentlyContinue
@@ -22,7 +35,7 @@ function Import-RemoteDesktopModule
     if ($null -ne $rdmsService -and $rdmsService.Status -ne 'Running')
     {
         Start-Service -Name RDMS -ErrorAction Stop
-        Start-Sleep -Seconds 2
+        $rdmsService.WaitForStatus('Running', [TimeSpan]::FromSeconds(30))
     }
 
     if (-not (Get-Module -Name RemoteDesktop))

--- a/tests/Unit/DSC_RDCertificateConfiguration.Tests.ps1
+++ b/tests/Unit/DSC_RDCertificateConfiguration.Tests.ps1
@@ -59,7 +59,7 @@ AfterAll {
 
 Describe 'DSC_RDCertificateConfiguration\Get-TargetResource' -Tag 'Get' {
     BeforeAll {
-        Mock -CommandName Assert-Module
+        Mock -CommandName Import-RemoteDesktopModule
     }
 
     Context 'When the system is in the desired state' {
@@ -94,7 +94,7 @@ Describe 'DSC_RDCertificateConfiguration\Get-TargetResource' -Tag 'Get' {
                 $result.Credential.UserName | Should -Be $testParams.Credential.UserName
             }
 
-            Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Get-RDCertificate -Exactly -Times 1 -Scope It
         }
     }
@@ -126,7 +126,7 @@ Describe 'DSC_RDCertificateConfiguration\Get-TargetResource' -Tag 'Get' {
                 $result.Credential.UserName | Should -BeNullOrEmpty
             }
 
-            Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Get-RDCertificate -Exactly -Times 1 -Scope It
         }
     }
@@ -134,7 +134,7 @@ Describe 'DSC_RDCertificateConfiguration\Get-TargetResource' -Tag 'Get' {
 
 Describe 'DSC_RDCertificateConfiguration\Test-TargetResource' -Tag 'Test' {
     BeforeAll {
-        Mock -CommandName Assert-Module
+        Mock -CommandName Import-RemoteDesktopModule
     }
 
     Context 'When the system is in the desired state' {
@@ -258,7 +258,7 @@ Describe 'DSC_RDCertificateConfiguration\Test-TargetResource' -Tag 'Test' {
 
 Describe 'DSC_RDCertificateConfiguration\Set-TargetResource' -Tag 'Set' {
     BeforeAll {
-        Mock -CommandName Assert-Module
+        Mock -CommandName Import-RemoteDesktopModule
     }
 
     Context 'When setting the resource' {
@@ -280,7 +280,7 @@ Describe 'DSC_RDCertificateConfiguration\Set-TargetResource' -Tag 'Set' {
                 $null = Set-TargetResource @testParams
             }
 
-            Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Set-RDCertificate -Exactly -Times 1 -Scope It
         }
     }
@@ -305,7 +305,7 @@ Describe 'DSC_RDCertificateConfiguration\Set-TargetResource' -Tag 'Set' {
                 $null = Set-TargetResource @testParams
             }
 
-            Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Set-RDCertificate -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Write-Error -Exactly -Times 1 -Scope It
         }

--- a/tests/Unit/DSC_RDConnectionBrokerHAMode.Tests.ps1
+++ b/tests/Unit/DSC_RDConnectionBrokerHAMode.Tests.ps1
@@ -60,7 +60,7 @@ Describe 'DSC_RDConnectionBrokerHAMode\Get-TargetResource' -Tag 'Get' {
     Context 'When the resource is in the desired state' {
         Context 'When the connection broker is not local' {
             BeforeAll {
-                Mock -CommandName Assert-Module
+                Mock -CommandName Import-RemoteDesktopModule
                 Mock -CommandName Get-RDConnectionBrokerHighAvailability -MockWith {
                     @{
                         ConnectionBroker                  = 'RDCB1'
@@ -95,14 +95,14 @@ Describe 'DSC_RDConnectionBrokerHAMode\Get-TargetResource' -Tag 'Get' {
                     $result.DatabaseFilePath | Should -Be $testParams.DatabaseFilePath
                 }
 
-                Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Get-RDConnectionBrokerHighAvailability -Exactly -Times 1 -Scope It
             }
         }
 
         Context 'When the connection broker is local' {
             BeforeAll {
-                Mock -CommandName Assert-Module
+                Mock -CommandName Import-RemoteDesktopModule
                 Mock -CommandName Get-RDConnectionBrokerHighAvailability -MockWith {
                     @{
                         ConnectionBroker                  = Get-ComputerName
@@ -136,7 +136,7 @@ Describe 'DSC_RDConnectionBrokerHAMode\Get-TargetResource' -Tag 'Get' {
                     $result.DatabaseFilePath | Should -Be $testParams.DatabaseFilePath
                 }
 
-                Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Get-RDConnectionBrokerHighAvailability -Exactly -Times 1 -Scope It
             }
         }
@@ -144,7 +144,7 @@ Describe 'DSC_RDConnectionBrokerHAMode\Get-TargetResource' -Tag 'Get' {
 
     Context 'When the resource is not in the desired state' {
         BeforeAll {
-            Mock -CommandName Assert-Module
+            Mock -CommandName Import-RemoteDesktopModule
             Mock -CommandName Get-RDConnectionBrokerHighAvailability
         }
 
@@ -170,7 +170,7 @@ Describe 'DSC_RDConnectionBrokerHAMode\Get-TargetResource' -Tag 'Get' {
                 $result.DatabaseFilePath | Should -BeNullOrEmpty
             }
 
-            Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Get-RDConnectionBrokerHighAvailability -Exactly -Times 1 -Scope It
         }
     }
@@ -243,7 +243,7 @@ Describe 'DSC_RDConnectionBrokerHAMode\Test-TargetResource' -Tag 'Test' {
 Describe 'DSC_RDConnectionBrokerHAMode\Set-TargetResource' -Tag 'Set' {
     Context 'When Set-RDConnectionBrokerHighAvailability runs successfully' {
         BeforeAll {
-            Mock -CommandName Assert-Module
+            Mock -CommandName Import-RemoteDesktopModule
             Mock -CommandName Set-RDConnectionBrokerHighAvailability
         }
 
@@ -262,7 +262,7 @@ Describe 'DSC_RDConnectionBrokerHAMode\Set-TargetResource' -Tag 'Set' {
                 $null = Set-TargetResource @testParams
             }
 
-            Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Set-RDConnectionBrokerHighAvailability -Exactly -Times 1 -Scope It
         }
     }

--- a/tests/Unit/DSC_RDGatewayConfiguration.Tests.ps1
+++ b/tests/Unit/DSC_RDGatewayConfiguration.Tests.ps1
@@ -59,7 +59,7 @@ AfterAll {
 Describe 'DSC_RDGatewayConfiguration\Get-TargetResource' -Tag 'Get' {
     Context 'When the resource exists' {
         BeforeAll {
-            Mock -CommandName Assert-Module
+            Mock -CommandName Import-RemoteDesktopModule
         }
 
         Context 'When ''GatewayMode'' is not Custom' {
@@ -123,7 +123,7 @@ Describe 'DSC_RDGatewayConfiguration\Get-TargetResource' -Tag 'Get' {
 
     Context 'When the resource does not exist' {
         BeforeAll {
-            Mock -CommandName Assert-Module
+            Mock -CommandName Import-RemoteDesktopModule
             Mock -CommandName Get-RDDeploymentGatewayConfiguration
         }
 
@@ -151,7 +151,7 @@ Describe 'DSC_RDGatewayConfiguration\Get-TargetResource' -Tag 'Get' {
 Describe 'DSC_RDGatewayConfiguration\Set-TargetResource' -Tag 'Set' {
     Context 'When ''GatewayMode'' is not Custom' {
         BeforeAll {
-            Mock -CommandName Assert-Module
+            Mock -CommandName Import-RemoteDesktopModule
             Mock -CommandName Assert-BoundParameter -RemoveParameterType @('RequiredBehavior')
             Mock -CommandName Set-RDDeploymentGatewayConfiguration
             Mock -CommandName Get-RDServer
@@ -172,7 +172,7 @@ Describe 'DSC_RDGatewayConfiguration\Set-TargetResource' -Tag 'Set' {
                         $null = Set-TargetResource @testParams
                     }
 
-                    Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                    Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                     Should -Invoke -CommandName Assert-BoundParameter -Exactly -Times 0 -Scope It
                     Should -Invoke -CommandName Set-RDDeploymentGatewayConfiguration -Exactly -Times 1 -Scope It -ParameterFilter {
                         $null -eq $GatewayExternalFqdn
@@ -196,7 +196,7 @@ Describe 'DSC_RDGatewayConfiguration\Set-TargetResource' -Tag 'Set' {
                         $null = Set-TargetResource @testParams
                     }
 
-                    Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                    Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                     Should -Invoke -CommandName Assert-BoundParameter -Exactly -Times 0 -Scope It
                     Should -Invoke -CommandName Set-RDDeploymentGatewayConfiguration -Exactly -Times 1 -Scope It -ParameterFilter {
                         $null -eq $GatewayExternalFqdn
@@ -245,7 +245,7 @@ Describe 'DSC_RDGatewayConfiguration\Set-TargetResource' -Tag 'Set' {
                         $null = Set-TargetResource @testParams
                     }
 
-                    Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                    Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                     Should -Invoke -CommandName Assert-BoundParameter -Exactly -Times 0 -Scope It
                     Should -Invoke -CommandName Set-RDDeploymentGatewayConfiguration -Exactly -Times 1 -Scope It -ParameterFilter {
                         $null -eq $GatewayExternalFqdn
@@ -288,7 +288,7 @@ Describe 'DSC_RDGatewayConfiguration\Set-TargetResource' -Tag 'Set' {
                         $null = Set-TargetResource @testParams
                     }
 
-                    Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                    Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                     Should -Invoke -CommandName Assert-BoundParameter -Exactly -Times 0 -Scope It
                     Should -Invoke -CommandName Set-RDDeploymentGatewayConfiguration -Exactly -Times 1 -Scope It -ParameterFilter {
                         $null -eq $GatewayExternalFqdn
@@ -302,7 +302,7 @@ Describe 'DSC_RDGatewayConfiguration\Set-TargetResource' -Tag 'Set' {
 
     Context 'When ''GatewayMode'' is Custom' {
         BeforeAll {
-            Mock -CommandName Assert-Module
+            Mock -CommandName Import-RemoteDesktopModule
             Mock -CommandName Assert-BoundParameter -RemoveParameterType @('RequiredBehavior')
             Mock -CommandName Set-RDDeploymentGatewayConfiguration
             Mock -CommandName Get-RDServer
@@ -322,7 +322,7 @@ Describe 'DSC_RDGatewayConfiguration\Set-TargetResource' -Tag 'Set' {
                     { Set-TargetResource @testParams } | Should -Throw
                 }
 
-                Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Assert-BoundParameter -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Set-RDDeploymentGatewayConfiguration -Exactly -Times 0 -Scope It
                 Should -Invoke -CommandName Get-RDServer -Exactly -Times 0 -Scope It
@@ -347,7 +347,7 @@ Describe 'DSC_RDGatewayConfiguration\Set-TargetResource' -Tag 'Set' {
                     $null = Set-TargetResource @testParams
                 }
 
-                Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Assert-BoundParameter -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Set-RDDeploymentGatewayConfiguration -Exactly -Times 1 -Scope It -ParameterFilter {
                     $null -ne $GatewayExternalFqdn
@@ -375,7 +375,7 @@ Describe 'DSC_RDGatewayConfiguration\Set-TargetResource' -Tag 'Set' {
                     $null = Set-TargetResource @testParams
                 }
 
-                Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Assert-BoundParameter -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Set-RDDeploymentGatewayConfiguration -Exactly -Times 1 -Scope It -ParameterFilter {
                     $null -ne $GatewayExternalFqdn

--- a/tests/Unit/DSC_RDGatewayConfiguration.Tests.ps1
+++ b/tests/Unit/DSC_RDGatewayConfiguration.Tests.ps1
@@ -84,6 +84,8 @@ Describe 'DSC_RDGatewayConfiguration\Get-TargetResource' -Tag 'Get' {
                     $result.ConnectionBroker | Should -Be $testParams.ConnectionBroker
                     $result.GatewayMode | Should -Be 'Automatic'
                 }
+
+                Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
             }
         }
 
@@ -117,6 +119,8 @@ Describe 'DSC_RDGatewayConfiguration\Get-TargetResource' -Tag 'Get' {
                     $result.UseCachedCredentials | Should -BeTrue
                     $result.BypassLocal | Should -BeFalse
                 }
+
+                Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
             }
         }
     }
@@ -144,6 +148,8 @@ Describe 'DSC_RDGatewayConfiguration\Get-TargetResource' -Tag 'Get' {
                 $result.UseCachedCredentials | Should -BeNullOrEmpty
                 $result.BypassLocal | Should -BeNullOrEmpty
             }
+
+            Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
         }
     }
 }

--- a/tests/Unit/DSC_RDLicenseConfiguration.Tests.ps1
+++ b/tests/Unit/DSC_RDLicenseConfiguration.Tests.ps1
@@ -59,7 +59,7 @@ AfterAll {
 Describe 'DSC_RDLicenseConfiguration\Get-TargetResource' -Tag 'Get' {
     Context 'When the resource exists' {
         BeforeAll {
-            Mock -CommandName Assert-Module
+            Mock -CommandName Import-RemoteDesktopModule
             Mock -CommandName Get-RDLicenseConfiguration -MockWith {
                 [PSCustomObject] @{
                     LicenseServer = [System.String[]] @('LicenseServer1', 'LicenseServer2')
@@ -85,14 +85,14 @@ Describe 'DSC_RDLicenseConfiguration\Get-TargetResource' -Tag 'Get' {
                 $result.LicenseMode | Should -Be $testParams.LicenseMode
             }
 
-            Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Get-RDLicenseConfiguration -Exactly -Times 1 -Scope It
         }
     }
 
     Context 'When the resource does not exist' {
         BeforeAll {
-            Mock -CommandName Assert-Module
+            Mock -CommandName Import-RemoteDesktopModule
             Mock -CommandName Get-RDLicenseConfiguration
         }
 
@@ -173,7 +173,7 @@ Describe 'DSC_RDLicenseConfiguration\Test-TargetResource' -Tag 'Test' {
 Describe 'DSC_RDLicenseConfiguration\Set-TargetResource' -Tag 'Set' {
     Context 'When the resource is updated' {
         BeforeAll {
-            Mock -CommandName Assert-Module
+            Mock -CommandName Import-RemoteDesktopModule
             Mock -CommandName Set-RDLicenseConfiguration
         }
 
@@ -191,7 +191,7 @@ Describe 'DSC_RDLicenseConfiguration\Set-TargetResource' -Tag 'Set' {
                     Set-TargetResource @testParams
                 }
 
-                Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Set-RDLicenseConfiguration -Exactly -Times 1 -Scope It -ParameterFilter {
                     $null -ne $LicenseServer
                 }
@@ -211,7 +211,7 @@ Describe 'DSC_RDLicenseConfiguration\Set-TargetResource' -Tag 'Set' {
                     Set-TargetResource @testParams
                 }
 
-                Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Set-RDLicenseConfiguration -Exactly -Times 1 -Scope It -ParameterFilter {
                     $null -eq $LicenseServer
                 }

--- a/tests/Unit/DSC_RDRemoteApp.Tests.ps1
+++ b/tests/Unit/DSC_RDRemoteApp.Tests.ps1
@@ -59,7 +59,7 @@ AfterAll {
 Describe 'DSC_RDRemoteApp\Get-TargetResource' -Tag 'Get' {
     Context 'When the resource exists' {
         BeforeAll {
-            Mock -CommandName Assert-Module
+            Mock -CommandName Import-RemoteDesktopModule
             Mock -CommandName Get-RDSessionCollection
             Mock -CommandName Get-RDRemoteApp -MockWith {
                 @{
@@ -117,7 +117,7 @@ Describe 'DSC_RDRemoteApp\Get-TargetResource' -Tag 'Get' {
                 $result.ShowInWebAccess | Should -Be $testParams.ShowInWebAccess
             }
 
-            Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Get-RDSessionCollection -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Get-RDRemoteApp -Exactly -Times 1 -Scope It
         }
@@ -125,7 +125,7 @@ Describe 'DSC_RDRemoteApp\Get-TargetResource' -Tag 'Get' {
 
     Context 'When the resource does not exist' {
         BeforeAll {
-            Mock -CommandName Assert-Module
+            Mock -CommandName Import-RemoteDesktopModule
             Mock -CommandName Get-RDSessionCollection
             Mock -CommandName Get-RDRemoteApp
         }
@@ -167,7 +167,7 @@ Describe 'DSC_RDRemoteApp\Get-TargetResource' -Tag 'Get' {
                 $result.ShowInWebAccess | Should -BeNullOrEmpty
             }
 
-            Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Get-RDSessionCollection -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Get-RDRemoteApp -Exactly -Times 1 -Scope It
         }
@@ -175,7 +175,7 @@ Describe 'DSC_RDRemoteApp\Get-TargetResource' -Tag 'Get' {
 
     Context 'When the collection does not exist' {
         BeforeAll {
-            Mock -CommandName Assert-Module
+            Mock -CommandName Import-RemoteDesktopModule
             Mock -CommandName Get-RDSessionCollection -MockWith {
                 throw 'Mock Error'
             }
@@ -206,7 +206,7 @@ Describe 'DSC_RDRemoteApp\Get-TargetResource' -Tag 'Get' {
                 { Get-TargetResource @testParams } | Should -Throw -ExpectedMessage "Failed to lookup RD Session Collection $($testParams.CollectionName). Error: Mock Error"
             }
 
-            Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Get-RDSessionCollection -Exactly -Times 1 -Scope It
         }
     }
@@ -215,7 +215,7 @@ Describe 'DSC_RDRemoteApp\Get-TargetResource' -Tag 'Get' {
 Describe 'DSC_RDRemoteApp\Set-TargetResource' -Tag 'Set' {
     Context 'When the resource should be created' {
         BeforeAll {
-            Mock -CommandName Assert-Module
+            Mock -CommandName Import-RemoteDesktopModule
             Mock -CommandName Get-RDSessionCollection
             Mock -CommandName Get-RDRemoteApp
             Mock -CommandName New-RDRemoteApp
@@ -246,7 +246,7 @@ Describe 'DSC_RDRemoteApp\Set-TargetResource' -Tag 'Set' {
                 $null = Set-TargetResource @testParams
             }
 
-            Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Get-RDSessionCollection -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Get-RDRemoteApp -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName New-RDRemoteApp -Exactly -Times 1 -Scope It
@@ -257,7 +257,7 @@ Describe 'DSC_RDRemoteApp\Set-TargetResource' -Tag 'Set' {
 
     Context 'When the resource should be removed' {
         BeforeAll {
-            Mock -CommandName Assert-Module
+            Mock -CommandName Import-RemoteDesktopModule
             Mock -CommandName Get-RDSessionCollection
             Mock -CommandName Get-RDRemoteApp -MockWith {
                 @{
@@ -293,7 +293,7 @@ Describe 'DSC_RDRemoteApp\Set-TargetResource' -Tag 'Set' {
                 $null = Set-TargetResource @testParams
             }
 
-            Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Get-RDSessionCollection -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Get-RDRemoteApp -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName New-RDRemoteApp -Exactly -Times 0 -Scope It
@@ -304,7 +304,7 @@ Describe 'DSC_RDRemoteApp\Set-TargetResource' -Tag 'Set' {
 
     Context 'When the resource should be updated' {
         BeforeAll {
-            Mock -CommandName Assert-Module
+            Mock -CommandName Import-RemoteDesktopModule
             Mock -CommandName Get-RDSessionCollection
             Mock -CommandName Get-RDRemoteApp -MockWith {
                 @{
@@ -340,7 +340,7 @@ Describe 'DSC_RDRemoteApp\Set-TargetResource' -Tag 'Set' {
                 $null = Set-TargetResource @testParams
             }
 
-            Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Get-RDSessionCollection -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Get-RDRemoteApp -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName New-RDRemoteApp -Exactly -Times 0 -Scope It
@@ -351,7 +351,7 @@ Describe 'DSC_RDRemoteApp\Set-TargetResource' -Tag 'Set' {
 
     Context 'When the collection does not exist' {
         BeforeAll {
-            Mock -CommandName Assert-Module
+            Mock -CommandName Import-RemoteDesktopModule
             Mock -CommandName Get-RDSessionCollection -MockWith {
                 throw 'Mock Error'
             }
@@ -385,7 +385,7 @@ Describe 'DSC_RDRemoteApp\Set-TargetResource' -Tag 'Set' {
                 { Set-TargetResource @testParams } | Should -Throw -ExpectedMessage 'Failed to lookup RD Session Collection TestCollection. Error: Mock Error'
             }
 
-            Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Get-RDSessionCollection -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Get-RDRemoteApp -Exactly -Times 0 -Scope It
             Should -Invoke -CommandName New-RDRemoteApp -Exactly -Times 0 -Scope It
@@ -398,7 +398,7 @@ Describe 'DSC_RDRemoteApp\Set-TargetResource' -Tag 'Set' {
 Describe 'DSC_RDRemoteApp\Test-TargetResource' -Tag 'Test' {
     Context 'When the resource is in the desired state' {
         BeforeAll {
-            Mock -CommandName Assert-Module
+            Mock -CommandName Import-RemoteDesktopModule
             Mock -CommandName Get-RDSessionCollection
             Mock -CommandName Get-TargetResource -MockWith {
                 @{
@@ -442,7 +442,7 @@ Describe 'DSC_RDRemoteApp\Test-TargetResource' -Tag 'Test' {
                 Test-TargetResource @testParams | Should -BeTrue
             }
 
-            Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Get-RDSessionCollection -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
         }
@@ -450,7 +450,7 @@ Describe 'DSC_RDRemoteApp\Test-TargetResource' -Tag 'Test' {
 
     Context 'When the resource is not in the desired state' {
         BeforeAll {
-            Mock -CommandName Assert-Module
+            Mock -CommandName Import-RemoteDesktopModule
             Mock -CommandName Get-RDSessionCollection
             Mock -CommandName Get-TargetResource -MockWith {
                 @{
@@ -542,7 +542,7 @@ Describe 'DSC_RDRemoteApp\Test-TargetResource' -Tag 'Test' {
                     Test-TargetResource @testParams | Should -BeFalse
                 }
 
-                Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Get-RDSessionCollection -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Get-TargetResource -Exactly -Times 1 -Scope It
             }
@@ -551,7 +551,7 @@ Describe 'DSC_RDRemoteApp\Test-TargetResource' -Tag 'Test' {
 
     Context 'When the collection does not exist' {
         BeforeAll {
-            Mock -CommandName Assert-Module
+            Mock -CommandName Import-RemoteDesktopModule
             Mock -CommandName Get-RDSessionCollection -MockWith {
                 throw 'Mock Error'
             }
@@ -582,7 +582,7 @@ Describe 'DSC_RDRemoteApp\Test-TargetResource' -Tag 'Test' {
                 { Test-TargetResource @testParams } | Should -Throw -ExpectedMessage 'Failed to lookup RD Session Collection TestCollection. Error: Mock Error'
             }
 
-            Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Get-RDSessionCollection -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Get-TargetResource -Exactly -Times 0 -Scope It
         }

--- a/tests/Unit/DSC_RDServer.Tests.ps1
+++ b/tests/Unit/DSC_RDServer.Tests.ps1
@@ -58,7 +58,7 @@ AfterAll {
 
 Describe 'DSC_RDServer\Get-TargetResource' -Tag 'Get' {
     BeforeAll {
-        Mock -CommandName Assert-Module
+        Mock -CommandName Import-RemoteDesktopModule
     }
 
     Context 'When the resource is present' {
@@ -93,7 +93,7 @@ Describe 'DSC_RDServer\Get-TargetResource' -Tag 'Get' {
                         $result.GatewayExternalFqdn | Should -BeNullOrEmpty
                     }
 
-                    Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                    Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                     Should -Invoke -CommandName Get-RDServer -Exactly -Times 1 -Scope It
                 }
             }
@@ -116,7 +116,7 @@ Describe 'DSC_RDServer\Get-TargetResource' -Tag 'Get' {
                         $result.GatewayExternalFqdn | Should -BeNullOrEmpty
                     }
 
-                    Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                    Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                     Should -Invoke -CommandName Get-RDServer -Exactly -Times 1 -Scope It
                 }
             }
@@ -150,7 +150,7 @@ Describe 'DSC_RDServer\Get-TargetResource' -Tag 'Get' {
                     $result.GatewayExternalFqdn | Should -Be $testParams.GatewayExternalFqdn
                 }
 
-                Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Get-RDServer -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Get-RDDeploymentGatewayConfiguration -Exactly -Times 1 -Scope It
             }
@@ -180,7 +180,7 @@ Describe 'DSC_RDServer\Get-TargetResource' -Tag 'Get' {
                     $result.GatewayExternalFqdn | Should -BeNullOrEmpty
                 }
 
-                Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Get-RDServer -Exactly -Times 1 -Scope It
             }
         }
@@ -214,7 +214,7 @@ Describe 'DSC_RDServer\Get-TargetResource' -Tag 'Get' {
                     $result.GatewayExternalFqdn | Should -BeNullOrEmpty
                 }
 
-                Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Get-RDServer -Exactly -Times 1 -Scope It
             }
         }
@@ -315,7 +315,7 @@ Describe 'DSC_RDServer\Test-TargetResource' -Tag 'Test' {
 
 Describe 'DSC_RDServer\Set-TargetResource' -Tag 'Set' {
     BeforeAll {
-        Mock -CommandName Assert-Module
+        Mock -CommandName Import-RemoteDesktopModule
     }
 
     Context 'When adding a resource' {
@@ -343,7 +343,7 @@ Describe 'DSC_RDServer\Set-TargetResource' -Tag 'Set' {
                         $null = Set-TargetResource @testParams
                     }
 
-                    Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                    Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                     Should -Invoke -CommandName Assert-BoundParameter -Exactly -Times 1 -Scope It
                     Should -Invoke -CommandName Add-RDServer -Exactly -Times 1 -Scope It
                 }
@@ -376,7 +376,7 @@ Describe 'DSC_RDServer\Set-TargetResource' -Tag 'Set' {
                         $null = Set-TargetResource @testParams
                     }
 
-                    Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                    Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                     Should -Invoke -CommandName Assert-BoundParameter -Exactly -Times 1 -Scope It
                     Should -Invoke -CommandName Add-RDServer -Exactly -Times 1 -Scope It
                 }
@@ -408,7 +408,7 @@ Describe 'DSC_RDServer\Set-TargetResource' -Tag 'Set' {
                         { Set-TargetResource @testParams } | Should -Throw
                     }
 
-                    Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                    Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                     Should -Invoke -CommandName Assert-BoundParameter -Exactly -Times 1 -Scope It
                     Should -Invoke -CommandName Add-RDServer -Exactly -Times 1 -Scope It
                 }
@@ -433,7 +433,7 @@ Describe 'DSC_RDServer\Set-TargetResource' -Tag 'Set' {
                         $null = Set-TargetResource @testParams
                     }
 
-                    Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                    Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                     Should -Invoke -CommandName Add-RDServer -Exactly -Times 1 -Scope It
                 }
             }
@@ -452,7 +452,7 @@ Describe 'DSC_RDServer\Set-TargetResource' -Tag 'Set' {
                         $null = Set-TargetResource @testParams
                     }
 
-                    Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                    Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                     Should -Invoke -CommandName Add-RDServer -Exactly -Times 1 -Scope It
                 }
             }

--- a/tests/Unit/DSC_RDSessionCollection.Tests.ps1
+++ b/tests/Unit/DSC_RDSessionCollection.Tests.ps1
@@ -58,7 +58,7 @@ AfterAll {
 
 Describe 'DSC_RDSessionCollection\Get-TargetResource' -Tag 'Get' {
     BeforeAll {
-        Mock -CommandName Assert-Module
+        Mock -CommandName Import-RemoteDesktopModule
     }
 
     Context 'When the resource is present' {
@@ -98,7 +98,7 @@ Describe 'DSC_RDSessionCollection\Get-TargetResource' -Tag 'Get' {
                     { Get-TargetResource @testParams } | Should -Throw -ExpectedMessage $errorRecord.Exception.Message
                 }
 
-                Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Get-RDSessionCollection -Exactly -Times 1 -Scope It
             }
         }
@@ -135,7 +135,7 @@ Describe 'DSC_RDSessionCollection\Get-TargetResource' -Tag 'Get' {
                     $result.Force | Should -Be $testParams.Force
                 }
 
-                Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Get-RDSessionCollection -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Get-RDSessionHost -Exactly -Times 1 -Scope It
             }
@@ -169,7 +169,7 @@ Describe 'DSC_RDSessionCollection\Get-TargetResource' -Tag 'Get' {
                     $result.Force | Should -Be $testParams.Force
                 }
 
-                Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Get-RDSessionCollection -Exactly -Times 1 -Scope It
             }
         }
@@ -211,7 +211,7 @@ Describe 'DSC_RDSessionCollection\Get-TargetResource' -Tag 'Get' {
                     $result.Force | Should -Be $testParams.Force
                 }
 
-                Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Get-RDSessionCollection -Exactly -Times 1 -Scope It
             }
         }
@@ -220,7 +220,7 @@ Describe 'DSC_RDSessionCollection\Get-TargetResource' -Tag 'Get' {
 
 Describe 'DSC_RDSessionCollection\Set-TargetResource' -Tag 'Set' {
     BeforeAll {
-        Mock -CommandName Assert-Module
+        Mock -CommandName Import-RemoteDesktopModule
     }
 
     Context 'When the resource is present' {

--- a/tests/Unit/DSC_RDSessionCollectionConfiguration.Tests.ps1
+++ b/tests/Unit/DSC_RDSessionCollectionConfiguration.Tests.ps1
@@ -58,7 +58,7 @@ AfterAll {
 
 Describe 'DSC_RDSessionCollectionConfiguration\Get-TargetResource' -Tag 'Get' {
     BeforeAll {
-        Mock -CommandName Assert-Module
+        Mock -CommandName Import-RemoteDesktopModule
     }
 
     Context 'When the resource is present' {
@@ -260,7 +260,7 @@ Describe 'DSC_RDSessionCollectionConfiguration\Get-TargetResource' -Tag 'Get' {
 
 Describe 'DSC_RDSessionCollectionConfiguration\Set-TargetResource' -Tag 'Set' {
     BeforeAll {
-        Mock -CommandName Assert-Module
+        Mock -CommandName Import-RemoteDesktopModule
     }
 
     Context 'When the session collection does not exist' {
@@ -281,7 +281,7 @@ Describe 'DSC_RDSessionCollectionConfiguration\Set-TargetResource' -Tag 'Set' {
                 { Set-TargetResource @testParams } | Should -Throw
             }
 
-            Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
         }
     }
 
@@ -334,7 +334,7 @@ Describe 'DSC_RDSessionCollectionConfiguration\Set-TargetResource' -Tag 'Set' {
                     $null = Set-TargetResource @testParams
                 }
 
-                Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Get-RemoteDesktopServicesDscOsVersion -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Get-RDSessionCollection -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Set-RDSessionCollectionConfiguration -ParameterFilter { $null -eq $DiskPath } -Exactly -Times 1 -Scope It
@@ -394,7 +394,7 @@ Describe 'DSC_RDSessionCollectionConfiguration\Set-TargetResource' -Tag 'Set' {
                             { Set-TargetResource @testParams } | Should -Throw -ExpectedMessage $errorRecord.Exception.Message
                         }
 
-                        Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                        Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                         Should -Invoke -CommandName Get-RemoteDesktopServicesDscOsVersion -Exactly -Times 1 -Scope It
                         Should -Invoke -CommandName Get-RDSessionCollection -Exactly -Times 1 -Scope It
                         Should -Invoke -CommandName Set-RDSessionCollectionConfiguration -ParameterFilter { $null -eq $EnableUserProfileDisk } -Exactly -Times 1 -Scope It
@@ -445,7 +445,7 @@ Describe 'DSC_RDSessionCollectionConfiguration\Set-TargetResource' -Tag 'Set' {
                             { Set-TargetResource @testParams } | Should -Throw -ExpectedMessage $errorRecord.Exception.Message
                         }
 
-                        Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                        Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                         Should -Invoke -CommandName Get-RemoteDesktopServicesDscOsVersion -Exactly -Times 1 -Scope It
                         Should -Invoke -CommandName Get-RDSessionCollection -Exactly -Times 1 -Scope It
                         Should -Invoke -CommandName Set-RDSessionCollectionConfiguration -ParameterFilter { $null -eq $EnableUserProfileDisk } -Exactly -Times 1 -Scope It
@@ -499,7 +499,7 @@ Describe 'DSC_RDSessionCollectionConfiguration\Set-TargetResource' -Tag 'Set' {
                             { Set-TargetResource @testParams } | Should -Throw -ExpectedMessage $errorRecord.Exception.Message
                         }
 
-                        Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                        Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                         Should -Invoke -CommandName Get-RemoteDesktopServicesDscOsVersion -Exactly -Times 1 -Scope It
                         Should -Invoke -CommandName Get-RDSessionCollection -Exactly -Times 1 -Scope It
                         Should -Invoke -CommandName Set-RDSessionCollectionConfiguration -ParameterFilter { $null -eq $EnableUserProfileDisk } -Exactly -Times 1 -Scope It
@@ -549,7 +549,7 @@ Describe 'DSC_RDSessionCollectionConfiguration\Set-TargetResource' -Tag 'Set' {
                             $null = Set-TargetResource @testParams
                         }
 
-                        Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                        Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                         Should -Invoke -CommandName Get-RemoteDesktopServicesDscOsVersion -Exactly -Times 1 -Scope It
                         Should -Invoke -CommandName Get-RDSessionCollection -Exactly -Times 1 -Scope It
                         Should -Invoke -CommandName Set-RDSessionCollectionConfiguration -ParameterFilter { $null -eq $EnableUserProfileDisk } -Exactly -Times 1 -Scope It
@@ -593,7 +593,7 @@ Describe 'DSC_RDSessionCollectionConfiguration\Set-TargetResource' -Tag 'Set' {
                         $null = Set-TargetResource @testParams
                     }
 
-                    Should -Invoke -CommandName Assert-Module -Exactly -Times 1 -Scope It
+                    Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
                     Should -Invoke -CommandName Get-RemoteDesktopServicesDscOsVersion -Exactly -Times 1 -Scope It
                     Should -Invoke -CommandName Get-RDSessionCollection -Exactly -Times 1 -Scope It
                     Should -Invoke -CommandName Set-RDSessionCollectionConfiguration -ParameterFilter { $null -eq $DisableUserProfileDisk } -Exactly -Times 1 -Scope It

--- a/tests/Unit/DSC_RDSessionDeployment.Tests.ps1
+++ b/tests/Unit/DSC_RDSessionDeployment.Tests.ps1
@@ -58,43 +58,33 @@ AfterAll {
 
 Describe 'DSC_RDSessionDeployment\Get-TargetResource' -Tag 'Get' {
     BeforeAll {
-        Mock -CommandName Assert-Module
+        Mock -CommandName Import-RemoteDesktopModule
     }
 
     Context 'When the resource is not present' {
         BeforeAll {
-            Mock -CommandName Get-Service
-            Mock -CommandName Start-Service -MockWith {
-                throw 'Cannot find any service with service name ''RDMS''.'
-            }
-
             Mock -CommandName Get-RDServer
         }
 
-        Context 'When the RDMS service is not present' {
-            It 'Should return the correct result' {
-                InModuleScope -ScriptBlock {
-                    Set-StrictMode -Version 1.0
+        It 'Should return the correct result' {
+            InModuleScope -ScriptBlock {
+                Set-StrictMode -Version 1.0
 
-                    $testParams = @{
-                        SessionHost      = 'sessionhost.lan'
-                        ConnectionBroker = 'connectionbroker.lan'
-                        WebAccessServer  = 'webaccess.lan'
-                    }
-
-                    $result = Get-TargetResource @testParams -WarningVariable serviceWarning -WarningAction SilentlyContinue
-
-                    $result.SessionHost | Should -BeNullOrEmpty
-                    $result.ConnectionBroker | Should -BeNullOrEmpty
-                    $result.WebAccessServer | Should -BeNullOrEmpty
-
-                    $serviceWarning | Should -BeLike "Failed to start RDMS service. Error: 'Cannot find any service with service name 'RDMS'.'."
+                $testParams = @{
+                    SessionHost      = 'sessionhost.lan'
+                    ConnectionBroker = 'connectionbroker.lan'
+                    WebAccessServer  = 'webaccess.lan'
                 }
 
-                Should -Invoke -CommandName Get-Service -Exactly -Times 1 -Scope It
-                Should -Invoke -CommandName Start-Service -Exactly -Times 1 -Scope It
-                Should -Invoke -CommandName Get-RDServer -Exactly -Times 1 -Scope It
+                $result = Get-TargetResource @testParams
+
+                $result.SessionHost | Should -BeNullOrEmpty
+                $result.ConnectionBroker | Should -BeNullOrEmpty
+                $result.WebAccessServer | Should -BeNullOrEmpty
             }
+
+            Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Get-RDServer -Exactly -Times 1 -Scope It
         }
     }
 
@@ -120,101 +110,27 @@ Describe 'DSC_RDSessionDeployment\Get-TargetResource' -Tag 'Get' {
                     )
                 }
             }
-
-            Mock -CommandName Start-Service
-            Mock -CommandName Get-Service -MockWith {
-                [PSCustomObject] @{
-                    Status = 'Stopped'
-                }
-            }
         }
 
-        Context 'When the RDMS service is stopped' {
-            It 'Should return the correct result' {
-                InModuleScope -ScriptBlock {
-                    Set-StrictMode -Version 1.0
+        It 'Should return the correct result' {
+            InModuleScope -ScriptBlock {
+                Set-StrictMode -Version 1.0
 
-                    $testParams = @{
-                        SessionHost      = [System.String[]] 'sessionhost.lan'
-                        ConnectionBroker = 'connectionbroker.lan'
-                        WebAccessServer  = [System.String[]] 'webaccess.lan'
-                    }
-
-                    $result = Get-TargetResource @testParams
-
-                    $result.SessionHost | Should -Be $testParams.SessionHost
-                    $result.ConnectionBroker | Should -Be $testParams.ConnectionBroker
-                    $result.WebAccessServer | Should -Be $testParams.WebAccessServer
+                $testParams = @{
+                    SessionHost      = [System.String[]] 'sessionhost.lan'
+                    ConnectionBroker = 'connectionbroker.lan'
+                    WebAccessServer  = [System.String[]] 'webaccess.lan'
                 }
 
-                Should -Invoke -CommandName Get-Service -Exactly -Times 1 -Scope It
-                Should -Invoke -CommandName Start-Service -Exactly -Times 1 -Scope It
-                Should -Invoke -CommandName Get-RDServer -Exactly -Times 1 -Scope It
-            }
-        }
+                $result = Get-TargetResource @testParams
 
-        Context 'When the RDMS service fails to start' {
-            BeforeAll {
-                Mock -CommandName Start-Service -MockWith {
-                    throw 'Throwing from Start-Service mock'
-                }
+                $result.SessionHost | Should -Be $testParams.SessionHost
+                $result.ConnectionBroker | Should -Be $testParams.ConnectionBroker
+                $result.WebAccessServer | Should -Be $testParams.WebAccessServer
             }
 
-            It 'Should return the correct result' {
-                InModuleScope -ScriptBlock {
-                    Set-StrictMode -Version 1.0
-
-                    $testParams = @{
-                        SessionHost      = 'sessionhost.lan'
-                        ConnectionBroker = 'connectionbroker.lan'
-                        WebAccessServer  = 'webaccess.lan'
-                    }
-
-                    $result = Get-TargetResource @testParams -WarningVariable serviceWarning -WarningAction SilentlyContinue
-
-                    $result.SessionHost | Should -Be $testParams.SessionHost
-                    $result.ConnectionBroker | Should -Be $testParams.ConnectionBroker
-                    $result.WebAccessServer | Should -Be $testParams.WebAccessServer
-
-                    $serviceWarning | Should -BeLike "Failed to start RDMS service. Error: 'Throwing from Start-Service mock'."
-                }
-
-                Should -Invoke -CommandName Get-Service -Exactly -Times 1 -Scope It
-                Should -Invoke -CommandName Start-Service -Exactly -Times 1 -Scope It
-                Should -Invoke -CommandName Get-RDServer -Exactly -Times 1 -Scope It
-            }
-        }
-
-        Context 'When the RDMS service is already running' {
-            BeforeAll {
-                Mock -CommandName Get-Service -MockWith {
-                    [PSCustomObject]@{
-                        Status = 'Running'
-                    }
-                }
-            }
-
-            It 'Should return the correct result' {
-                InModuleScope -ScriptBlock {
-                    Set-StrictMode -Version 1.0
-
-                    $testParams = @{
-                        SessionHost      = 'sessionhost.lan'
-                        ConnectionBroker = 'connectionbroker.lan'
-                        WebAccessServer  = 'webaccess.lan'
-                    }
-
-                    $result = Get-TargetResource @testParams
-
-                    $result.SessionHost | Should -Be $testParams.SessionHost
-                    $result.ConnectionBroker | Should -Be $testParams.ConnectionBroker
-                    $result.WebAccessServer | Should -Be $testParams.WebAccessServer
-                }
-
-                Should -Invoke -CommandName Get-Service -Exactly -Times 1 -Scope It
-                Should -Invoke -CommandName Start-Service -Exactly -Times 0 -Scope It
-                Should -Invoke -CommandName Get-RDServer -Exactly -Times 1 -Scope It
-            }
+            Should -Invoke -CommandName Import-RemoteDesktopModule -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Get-RDServer -Exactly -Times 1 -Scope It
         }
     }
 }
@@ -222,7 +138,7 @@ Describe 'DSC_RDSessionDeployment\Get-TargetResource' -Tag 'Get' {
 Describe 'DSC_RDSessionDeployment\Set-TargetResource' -Tag 'Set' {
     Context 'When the resource is not in the desired state' {
         BeforeAll {
-            Mock -CommandName Assert-Module
+            Mock -CommandName Import-RemoteDesktopModule
             Mock -CommandName New-RDSessionDeployment
             Mock -CommandName Add-RDServer
             Mock -CommandName Remove-RDServer

--- a/tests/Unit/RemoteDesktopServicesDsc.Common/Public/Import-RemoteDesktopModule.Tests.ps1
+++ b/tests/Unit/RemoteDesktopServicesDsc.Common/Public/Import-RemoteDesktopModule.Tests.ps1
@@ -1,0 +1,186 @@
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+param ()
+
+BeforeDiscovery {
+    try
+    {
+        if (-not (Get-Module -Name 'DscResource.Test'))
+        {
+            # Assumes dependencies has been resolved, so if this module is not available, run 'noop' task.
+            if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
+            {
+                # Redirect all streams to $null, except the error stream (stream 2)
+                & "$PSScriptRoot/../../../../build.ps1" -Tasks 'noop' 3>&1 4>&1 5>&1 6>&1 > $null
+            }
+
+            # If the dependencies has not been resolved, this will throw an error.
+            Import-Module -Name 'DscResource.Test' -Force -ErrorAction 'Stop'
+        }
+    }
+    catch [System.IO.FileNotFoundException]
+    {
+        throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -ResolveDependency -Tasks build" first.'
+    }
+}
+
+BeforeAll {
+    $script:dscModuleName = 'RemoteDesktopServicesDsc'
+    $script:subModuleName = 'RemoteDesktopServicesDsc.Common'
+
+    $script:parentModule = Get-Module -Name $script:dscModuleName -ListAvailable | Select-Object -First 1
+    $script:subModulesFolder = Join-Path -Path $script:parentModule.ModuleBase -ChildPath 'Modules'
+
+    $script:subModulePath = Join-Path -Path $script:subModulesFolder -ChildPath $script:subModuleName
+
+    Import-Module -Name $script:subModulePath -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:subModuleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:subModuleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:subModuleName
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    # Unload the module being tested so that it doesn't impact any other tests.
+    Get-Module -Name $script:subModuleName -All | Remove-Module -Force
+}
+
+Describe 'Import-RemoteDesktopModule' {
+    Context 'When the RDMS service is not present' {
+        BeforeAll {
+            Mock -CommandName Get-Service
+            Mock -CommandName Start-Service
+            Mock -CommandName Start-Sleep
+            Mock -CommandName Get-Module -MockWith { $false }
+            Mock -CommandName Import-Module
+        }
+
+        It 'Should not attempt to start the service' {
+            Import-RemoteDesktopModule
+
+            Should -Invoke -CommandName Get-Service -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Start-Service -Exactly -Times 0 -Scope It
+        }
+
+        It 'Should import the RemoteDesktop module globally' {
+            Import-RemoteDesktopModule
+
+            Should -Invoke -CommandName Import-Module -ParameterFilter {
+                $Name -eq 'RemoteDesktop' -and $Global -eq $true -and $Force -eq $true
+            } -Exactly -Times 1 -Scope It
+        }
+    }
+
+    Context 'When the RDMS service is stopped' {
+        BeforeAll {
+            Mock -CommandName Get-Service -MockWith {
+                [PSCustomObject] @{
+                    Status = 'Stopped'
+                }
+            }
+
+            Mock -CommandName Start-Service
+            Mock -CommandName Start-Sleep
+            Mock -CommandName Get-Module -MockWith { $false }
+            Mock -CommandName Import-Module
+        }
+
+        It 'Should start the RDMS service' {
+            Import-RemoteDesktopModule
+
+            Should -Invoke -CommandName Start-Service -ParameterFilter {
+                $Name -eq 'RDMS'
+            } -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Start-Sleep -Exactly -Times 1 -Scope It
+        }
+
+        It 'Should import the RemoteDesktop module' {
+            Import-RemoteDesktopModule
+
+            Should -Invoke -CommandName Import-Module -ParameterFilter {
+                $Name -eq 'RemoteDesktop' -and $Global -eq $true
+            } -Exactly -Times 1 -Scope It
+        }
+    }
+
+    Context 'When the RDMS service fails to start' {
+        BeforeAll {
+            Mock -CommandName Get-Service -MockWith {
+                [PSCustomObject] @{
+                    Status = 'Stopped'
+                }
+            }
+
+            Mock -CommandName Start-Service -MockWith {
+                throw 'Throwing from Start-Service mock'
+            }
+
+            Mock -CommandName Start-Sleep
+            Mock -CommandName Get-Module -MockWith { $false }
+            Mock -CommandName Import-Module
+        }
+
+        It 'Should throw an error' {
+            { Import-RemoteDesktopModule } | Should -Throw -ExpectedMessage 'Throwing from Start-Service mock'
+
+            Should -Invoke -CommandName Start-Service -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Import-Module -Exactly -Times 0 -Scope It
+        }
+    }
+
+    Context 'When the RDMS service is already running' {
+        BeforeAll {
+            Mock -CommandName Get-Service -MockWith {
+                [PSCustomObject] @{
+                    Status = 'Running'
+                }
+            }
+
+            Mock -CommandName Start-Service
+            Mock -CommandName Start-Sleep
+            Mock -CommandName Get-Module -MockWith { $false }
+            Mock -CommandName Import-Module
+        }
+
+        It 'Should not attempt to start the service' {
+            Import-RemoteDesktopModule
+
+            Should -Invoke -CommandName Get-Service -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Start-Service -Exactly -Times 0 -Scope It
+            Should -Invoke -CommandName Start-Sleep -Exactly -Times 0 -Scope It
+        }
+
+        It 'Should import the RemoteDesktop module' {
+            Import-RemoteDesktopModule
+
+            Should -Invoke -CommandName Import-Module -ParameterFilter {
+                $Name -eq 'RemoteDesktop' -and $Global -eq $true
+            } -Exactly -Times 1 -Scope It
+        }
+    }
+
+    Context 'When the RemoteDesktop module is already loaded' {
+        BeforeAll {
+            Mock -CommandName Get-Service -MockWith {
+                [PSCustomObject] @{
+                    Status = 'Running'
+                }
+            }
+
+            Mock -CommandName Start-Service
+            Mock -CommandName Start-Sleep
+            Mock -CommandName Get-Module -MockWith { $true }
+            Mock -CommandName Import-Module
+        }
+
+        It 'Should not import the module again' {
+            Import-RemoteDesktopModule
+
+            Should -Invoke -CommandName Get-Module -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Import-Module -Exactly -Times 0 -Scope It
+        }
+    }
+}

--- a/tests/Unit/RemoteDesktopServicesDsc.Common/Public/Import-RemoteDesktopModule.Tests.ps1
+++ b/tests/Unit/RemoteDesktopServicesDsc.Common/Public/Import-RemoteDesktopModule.Tests.ps1
@@ -88,7 +88,6 @@ Describe 'Import-RemoteDesktopModule' {
         BeforeAll {
             Mock -CommandName Get-Service
             Mock -CommandName Start-Service
-            Mock -CommandName Start-Sleep
             Mock -CommandName Get-Module -MockWith { $false }
             Mock -CommandName Import-Module
         }
@@ -112,13 +111,18 @@ Describe 'Import-RemoteDesktopModule' {
     Context 'When the RDMS service is stopped' {
         BeforeAll {
             Mock -CommandName Get-Service -MockWith {
-                [PSCustomObject] @{
+                $mockService = [PSCustomObject] @{
                     Status = 'Stopped'
                 }
+
+                $mockService | Add-Member -MemberType ScriptMethod -Name 'WaitForStatus' -Value {
+                    param ($Status, $Timeout)
+                }
+
+                return $mockService
             }
 
             Mock -CommandName Start-Service
-            Mock -CommandName Start-Sleep
             Mock -CommandName Get-Module -MockWith { $false }
             Mock -CommandName Import-Module
         }
@@ -129,7 +133,6 @@ Describe 'Import-RemoteDesktopModule' {
             Should -Invoke -CommandName Start-Service -ParameterFilter {
                 $Name -eq 'RDMS'
             } -Exactly -Times 1 -Scope It
-            Should -Invoke -CommandName Start-Sleep -Exactly -Times 1 -Scope It
         }
 
         It 'Should import the RemoteDesktop module' {
@@ -144,16 +147,21 @@ Describe 'Import-RemoteDesktopModule' {
     Context 'When the RDMS service fails to start' {
         BeforeAll {
             Mock -CommandName Get-Service -MockWith {
-                [PSCustomObject] @{
+                $mockService = [PSCustomObject] @{
                     Status = 'Stopped'
                 }
+
+                $mockService | Add-Member -MemberType ScriptMethod -Name 'WaitForStatus' -Value {
+                    param ($Status, $Timeout)
+                }
+
+                return $mockService
             }
 
             Mock -CommandName Start-Service -MockWith {
                 throw 'Throwing from Start-Service mock'
             }
 
-            Mock -CommandName Start-Sleep
             Mock -CommandName Get-Module -MockWith { $false }
             Mock -CommandName Import-Module
         }
@@ -175,7 +183,6 @@ Describe 'Import-RemoteDesktopModule' {
             }
 
             Mock -CommandName Start-Service
-            Mock -CommandName Start-Sleep
             Mock -CommandName Get-Module -MockWith { $false }
             Mock -CommandName Import-Module
         }
@@ -185,7 +192,6 @@ Describe 'Import-RemoteDesktopModule' {
 
             Should -Invoke -CommandName Get-Service -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Start-Service -Exactly -Times 0 -Scope It
-            Should -Invoke -CommandName Start-Sleep -Exactly -Times 0 -Scope It
         }
 
         It 'Should import the RemoteDesktop module' {
@@ -206,7 +212,6 @@ Describe 'Import-RemoteDesktopModule' {
             }
 
             Mock -CommandName Start-Service
-            Mock -CommandName Start-Sleep
             Mock -CommandName Get-Module -MockWith { $true }
             Mock -CommandName Import-Module
         }

--- a/tests/Unit/RemoteDesktopServicesDsc.Common/Public/Import-RemoteDesktopModule.Tests.ps1
+++ b/tests/Unit/RemoteDesktopServicesDsc.Common/Public/Import-RemoteDesktopModule.Tests.ps1
@@ -136,7 +136,7 @@ Describe 'Import-RemoteDesktopModule' {
             Import-RemoteDesktopModule
 
             Should -Invoke -CommandName Import-Module -ParameterFilter {
-                $Name -eq 'RemoteDesktop' -and $Global -eq $true
+                $Name -eq 'RemoteDesktop' -and $Global -eq $true -and $Force -eq $true
             } -Exactly -Times 1 -Scope It
         }
     }
@@ -192,7 +192,7 @@ Describe 'Import-RemoteDesktopModule' {
             Import-RemoteDesktopModule
 
             Should -Invoke -CommandName Import-Module -ParameterFilter {
-                $Name -eq 'RemoteDesktop' -and $Global -eq $true
+                $Name -eq 'RemoteDesktop' -and $Global -eq $true -and $Force -eq $true
             } -Exactly -Times 1 -Scope It
         }
     }

--- a/tests/Unit/RemoteDesktopServicesDsc.Common/Public/Import-RemoteDesktopModule.Tests.ps1
+++ b/tests/Unit/RemoteDesktopServicesDsc.Common/Public/Import-RemoteDesktopModule.Tests.ps1
@@ -27,14 +27,8 @@ BeforeAll {
     $script:dscModuleName = 'RemoteDesktopServicesDsc'
     $script:subModuleName = 'RemoteDesktopServicesDsc.Common'
 
-    # Derive the repository root from $PSScriptRoot so the test always loads the
-    # built module from the build output rather than a version on PSModulePath.
-    $script:repoRoot = Join-Path -Path $PSScriptRoot -ChildPath '../../../../' -Resolve
-    $script:builtModuleRoot = Join-Path -Path $script:repoRoot -ChildPath 'output/builtModule' -Resolve
-    $script:parentModuleBase = Get-ChildItem -Path (Join-Path -Path $script:builtModuleRoot -ChildPath $script:dscModuleName) -Directory |
-        Select-Object -First 1 |
-        Select-Object -ExpandProperty FullName
-    $script:subModulesFolder = Join-Path -Path $script:parentModuleBase -ChildPath 'Modules'
+    $script:parentModule = Get-Module -Name $script:dscModuleName -ListAvailable | Select-Object -First 1
+    $script:subModulesFolder = Join-Path -Path $script:parentModule.ModuleBase -ChildPath 'Modules'
 
     $script:subModulePath = Join-Path -Path $script:subModulesFolder -ChildPath $script:subModuleName
 

--- a/tests/Unit/RemoteDesktopServicesDsc.Common/Public/Import-RemoteDesktopModule.Tests.ps1
+++ b/tests/Unit/RemoteDesktopServicesDsc.Common/Public/Import-RemoteDesktopModule.Tests.ps1
@@ -27,8 +27,14 @@ BeforeAll {
     $script:dscModuleName = 'RemoteDesktopServicesDsc'
     $script:subModuleName = 'RemoteDesktopServicesDsc.Common'
 
-    $script:parentModule = Get-Module -Name $script:dscModuleName -ListAvailable | Select-Object -First 1
-    $script:subModulesFolder = Join-Path -Path $script:parentModule.ModuleBase -ChildPath 'Modules'
+    # Derive the repository root from $PSScriptRoot so the test always loads the
+    # built module from the build output rather than a version on PSModulePath.
+    $script:repoRoot = Join-Path -Path $PSScriptRoot -ChildPath '../../../../' -Resolve
+    $script:builtModuleRoot = Join-Path -Path $script:repoRoot -ChildPath 'output/builtModule' -Resolve
+    $script:parentModuleBase = Get-ChildItem -Path (Join-Path -Path $script:builtModuleRoot -ChildPath $script:dscModuleName) -Directory |
+        Select-Object -First 1 |
+        Select-Object -ExpandProperty FullName
+    $script:subModulesFolder = Join-Path -Path $script:parentModuleBase -ChildPath 'Modules'
 
     $script:subModulePath = Join-Path -Path $script:subModulesFolder -ChildPath $script:subModuleName
 

--- a/tests/Unit/RemoteDesktopServicesDsc.Common/Public/Import-RemoteDesktopModule.Tests.ps1
+++ b/tests/Unit/RemoteDesktopServicesDsc.Common/Public/Import-RemoteDesktopModule.Tests.ps1
@@ -1,4 +1,4 @@
-[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification = 'Required setup block per project template')]
 param ()
 
 BeforeDiscovery {

--- a/tests/Unit/RemoteDesktopServicesDsc.Common/Public/Import-RemoteDesktopModule.Tests.ps1
+++ b/tests/Unit/RemoteDesktopServicesDsc.Common/Public/Import-RemoteDesktopModule.Tests.ps1
@@ -54,6 +54,35 @@ AfterAll {
     Get-Module -Name $script:subModuleName -All | Remove-Module -Force
 }
 
+Describe 'Import-RemoteDesktopModule - Parameter Set Contract' {
+    BeforeAll {
+        $script:command = Get-Command -Name 'Import-RemoteDesktopModule'
+    }
+
+    It 'Should be a function' {
+        $script:command.CommandType | Should -Be 'Function'
+    }
+
+    It 'Should have exactly one parameter set named __AllParameterSets' {
+        $script:command.ParameterSets | Should -HaveCount 1
+        $script:command.ParameterSets[0].Name | Should -Be '__AllParameterSets'
+    }
+
+    It 'Should have no required parameters' {
+        $requiredParams = $script:command.ParameterSets[0].Parameters |
+            Where-Object { $_.IsMandatory -and $_.Name -notin [System.Management.Automation.Cmdlet]::CommonParameters }
+
+        $requiredParams | Should -BeNullOrEmpty
+    }
+
+    It 'Should have no custom parameters beyond common parameters' {
+        $customParams = $script:command.Parameters.Keys |
+            Where-Object { $_ -notin [System.Management.Automation.Cmdlet]::CommonParameters }
+
+        $customParams | Should -BeNullOrEmpty
+    }
+}
+
 Describe 'Import-RemoteDesktopModule' {
     Context 'When the RDMS service is not present' {
         BeforeAll {

--- a/tests/Unit/RemoteDesktopServicesDsc.Common/Public/Test-RemoteDesktopServicesDscOsRequirement.Tests.ps1
+++ b/tests/Unit/RemoteDesktopServicesDsc.Common/Public/Test-RemoteDesktopServicesDscOsRequirement.Tests.ps1
@@ -31,9 +31,16 @@ BeforeAll {
     # built module from the build output rather than a version on PSModulePath.
     $script:repoRoot = Join-Path -Path $PSScriptRoot -ChildPath '../../../../' -Resolve
     $script:builtModuleRoot = Join-Path -Path $script:repoRoot -ChildPath 'output/builtModule' -Resolve
-    $script:parentModuleBase = Get-ChildItem -Path (Join-Path -Path $script:builtModuleRoot -ChildPath $script:dscModuleName) -Directory |
+    $script:parentModuleSearchPath = Join-Path -Path $script:builtModuleRoot -ChildPath $script:dscModuleName
+    $script:parentModuleBase = Get-ChildItem -Path $script:parentModuleSearchPath -Directory |
+        Sort-Object -Property LastWriteTime -Descending |
         Select-Object -First 1 |
         Select-Object -ExpandProperty FullName
+
+    if (-not $script:parentModuleBase)
+    {
+        throw "No built module directory found under '$script:parentModuleSearchPath' for module '$script:dscModuleName'. Run '.\build.ps1 -ResolveDependency -Tasks build' first."
+    }
     $script:subModulesFolder = Join-Path -Path $script:parentModuleBase -ChildPath 'Modules'
 
     $script:subModulePath = Join-Path -Path $script:subModulesFolder -ChildPath $script:subModuleName

--- a/tests/Unit/RemoteDesktopServicesDsc.Common/Public/Test-RemoteDesktopServicesDscOsRequirement.Tests.ps1
+++ b/tests/Unit/RemoteDesktopServicesDsc.Common/Public/Test-RemoteDesktopServicesDscOsRequirement.Tests.ps1
@@ -27,8 +27,14 @@ BeforeAll {
     $script:dscModuleName = 'RemoteDesktopServicesDsc'
     $script:subModuleName = 'RemoteDesktopServicesDsc.Common'
 
-    $script:parentModule = Get-Module -Name $script:dscModuleName -ListAvailable | Select-Object -First 1
-    $script:subModulesFolder = Join-Path -Path $script:parentModule.ModuleBase -ChildPath 'Modules'
+    # Derive the repository root from $PSScriptRoot so the test always loads the
+    # built module from the build output rather than a version on PSModulePath.
+    $script:repoRoot = Join-Path -Path $PSScriptRoot -ChildPath '../../../../' -Resolve
+    $script:builtModuleRoot = Join-Path -Path $script:repoRoot -ChildPath 'output/builtModule' -Resolve
+    $script:parentModuleBase = Get-ChildItem -Path (Join-Path -Path $script:builtModuleRoot -ChildPath $script:dscModuleName) -Directory |
+        Select-Object -First 1 |
+        Select-Object -ExpandProperty FullName
+    $script:subModulesFolder = Join-Path -Path $script:parentModuleBase -ChildPath 'Modules'
 
     $script:subModulePath = Join-Path -Path $script:subModulesFolder -ChildPath $script:subModuleName
 

--- a/tests/Unit/RemoteDesktopServicesDsc.Common/Public/Test-RemoteDesktopServicesDscOsRequirement.Tests.ps1
+++ b/tests/Unit/RemoteDesktopServicesDsc.Common/Public/Test-RemoteDesktopServicesDscOsRequirement.Tests.ps1
@@ -27,21 +27,8 @@ BeforeAll {
     $script:dscModuleName = 'RemoteDesktopServicesDsc'
     $script:subModuleName = 'RemoteDesktopServicesDsc.Common'
 
-    # Derive the repository root from $PSScriptRoot so the test always loads the
-    # built module from the build output rather than a version on PSModulePath.
-    $script:repoRoot = Join-Path -Path $PSScriptRoot -ChildPath '../../../../' -Resolve
-    $script:builtModuleRoot = Join-Path -Path $script:repoRoot -ChildPath 'output/builtModule' -Resolve
-    $script:parentModuleSearchPath = Join-Path -Path $script:builtModuleRoot -ChildPath $script:dscModuleName
-    $script:parentModuleBase = Get-ChildItem -Path $script:parentModuleSearchPath -Directory |
-        Sort-Object -Property LastWriteTime -Descending |
-        Select-Object -First 1 |
-        Select-Object -ExpandProperty FullName
-
-    if (-not $script:parentModuleBase)
-    {
-        throw "No built module directory found under '$script:parentModuleSearchPath' for module '$script:dscModuleName'. Run '.\build.ps1 -ResolveDependency -Tasks build' first."
-    }
-    $script:subModulesFolder = Join-Path -Path $script:parentModuleBase -ChildPath 'Modules'
+    $script:parentModule = Get-Module -Name $script:dscModuleName -ListAvailable | Select-Object -First 1
+    $script:subModulesFolder = Join-Path -Path $script:parentModule.ModuleBase -ChildPath 'Modules'
 
     $script:subModulePath = Join-Path -Path $script:subModulesFolder -ChildPath $script:subModuleName
 


### PR DESCRIPTION
#### Pull Request (PR) description

RemoteDesktopServicesDsc 4.0.0 is completely broken when applied by the DSC LCM — every resource fails with `The term 'Get-RDServer' is not recognized`. The commands work fine in an interactive session; the failure only occurs inside the DSC WMI provider host process (`wmiprvse.exe`).

**Root cause:** All 9 `DSC_RD*.psm1` resource files call `Assert-Module -ModuleName 'RemoteDesktop' -ImportModule`. `Assert-Module` (from `DscResource.Common`) runs `Import-Module -Name RemoteDesktop` inside its own function scope. The `RemoteDesktop` module is a CDXML module — its cmdlets are WMI/CIM proxy functions generated at import time. Inside `wmiprvse.exe`, these proxy functions do not propagate from `Assert-Module`'s function scope back to the calling scope.

There is a secondary issue: the RDMS service uses `Automatic (Delayed Start)` and may not yet be running when the LCM kicks in after a reboot. The RemoteDesktop CDXML module requires the RDMS WMI namespace to be registered, so the import fails if the service hasn't started.

**Fix:**
- Added a shared helper function `Import-RemoteDesktopModule` to `RemoteDesktopServicesDsc.Common` that:
  1. Starts the RDMS service if it exists but is not running
  2. Imports the `RemoteDesktop` module with `-Global -Force` so CDXML proxy commands are visible across all scopes
- Replaced all 21 `Assert-Module -ModuleName 'RemoteDesktop' -ImportModule` calls across all 9 DSC resource files with the new helper
- Removed the now-redundant inline RDMS service start block from `DSC_RDSessionDeployment` `Get-TargetResource`
- Added 8 unit tests for the new `Import-RemoteDesktopModule` helper covering all RDMS service states
- Updated all existing unit tests to mock/assert the new function

#### This Pull Request (PR) fixes the following issues

- Fixes #136

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [x] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/RemoteDesktopServicesDsc/137)
<!-- Reviewable:end -->
